### PR TITLE
wip

### DIFF
--- a/src/serialize/BaseSerializer.ts
+++ b/src/serialize/BaseSerializer.ts
@@ -15,7 +15,9 @@ export abstract class BaseSerializer implements Serializer {
 
   #getAllBomRefs (bom: Bom): Iterable<BomRef> {
     const bomRefs = new Set<BomRef>()
-    bom.components.forEach(c => bomRefs.add(c.bomRef))
+    for (const c of bom.components) {
+      bomRefs.add(c.bomRef)
+    }
     if (bom.metadata.component !== null) {
       bomRefs.add(bom.metadata.component.bomRef)
     }

--- a/src/serialize/BomRefDiscriminator.ts
+++ b/src/serialize/BomRefDiscriminator.ts
@@ -13,20 +13,20 @@ export class BomRefDiscriminator {
 
   discriminate (): void {
     const knownRefValues = new Set<string>()
-    this.#originalValues.forEach((_, bomRef) => {
+    for (const [bomRef] of this.#originalValues) {
       let value = bomRef.value
       if (value === undefined || knownRefValues.has(value)) {
         value = this.#makeUniqueId()
         bomRef.value = value
       }
       knownRefValues.add(value)
-    })
+    }
   }
 
   reset (): void {
-    this.#originalValues.forEach((value, bomRef) => {
-      bomRef.value = value
-    })
+    for (const [bomRef, originalValue] of this.#originalValues) {
+      bomRef.value = originalValue
+    }
   }
 
   #makeUniqueId (): string {

--- a/src/serialize/JSON/normalize.ts
+++ b/src/serialize/JSON/normalize.ts
@@ -366,16 +366,18 @@ export class DependencyGraphNormalizer extends Base {
     }
 
     const allRefs = new Map<Models.BomRef, Models.BomRefRepository>()
-    data.components.forEach(c => allRefs.set(c.bomRef, new Models.BomRefRepository(c.dependencies)))
+    for (const c of data.components) {
+      allRefs.set(c.bomRef, new Models.BomRefRepository(c.dependencies))
+    }
     allRefs.set(data.metadata.component.bomRef, data.metadata.component.dependencies)
 
     const normalized: Types.Dependency[] = []
-    allRefs.forEach((deps, ref) => {
+    for (const [ref, deps] of allRefs) {
       const dep = this.#normalizeDependency(ref, deps, allRefs, options)
       if (isNotUndefined(dep)) {
         normalized.push(dep)
       }
-    })
+    }
 
     if (options.sortLists ?? false) {
       normalized.sort(({ ref: a }, { ref: b }) => a.localeCompare(b))

--- a/src/serialize/XML/normalize.ts
+++ b/src/serialize/XML/normalize.ts
@@ -469,16 +469,18 @@ export class DependencyGraphNormalizer extends Base {
     }
 
     const allRefs = new Map<Models.BomRef, Models.BomRefRepository>()
-    data.components.forEach(c => allRefs.set(c.bomRef, new Models.BomRefRepository(c.dependencies)))
+    for (const c of data.components) {
+      allRefs.set(c.bomRef, new Models.BomRefRepository(c.dependencies))
+    }
     allRefs.set(data.metadata.component.bomRef, data.metadata.component.dependencies)
 
     const normalized: Array<(Types.SimpleXml.Element & { attributes: { ref: string } })> = []
-    allRefs.forEach((deps, ref) => {
+    for (const [ref, deps] of allRefs) {
       const dep = this.#normalizeDependency(ref, deps, allRefs, options)
       if (isNotUndefined(dep)) {
         normalized.push(dep)
       }
-    })
+    }
 
     if (options.sortLists ?? false) {
       normalized.sort(({ attributes: { ref: a } }, { attributes: { ref: b } }) => a.localeCompare(b))


### PR DESCRIPTION
remove unnecessary function calls/ scope-switches, by opening the `.forEach()` loops 