### PR TITLE
Targetized split `module/module`

### DIFF
--- a/examples/web-browser.html
+++ b/examples/web-browser.html
@@ -24,6 +24,12 @@
         cdx.Spec.Spec1dot4))
     const serializedJson = jsonSerializer.serialize(bom)
     console.log(serializedJson)
+
+    const xmlSerializer = new cdx.Serialize.XmlSerializer(
+      new cdx.Serialize.XML.Normalize.Factory(
+        cdx.Spec.Spec1dot4))
+    const serializedXML = xmlSerializer.serialize(bom)
+    console.log(serializedXML)
   </script>
 </head>
 <body>

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "webpack-cli": "4.9.2"
   },
   "browser": "dist.web/lib.js",
-  "main": "dist.node/index.js",
-  "types": "src/index.ts",
+  "main": "dist.node/_index.node.js",
+  "types": "src/_index.node.ts",
   "directories": {
     "lib": "dist.node",
     "doc": "docs",
@@ -47,7 +47,7 @@
     "lint": "tsc --noEmit",
     "build": "npm run build:node && npm run build:web",
     "prebuild:node": "node -r fs -e 'fs.rmSync(\"dist.node\",{recursive:true,force:true})'",
-    "build:node": "tsc --build",
+    "build:node": "tsc -b ./tsconfig.node.json",
     "prebuild:web": "node -r fs -e 'fs.rmSync(\"dist.web\",{recursive:true,force:true})'",
     "build:web": "webpack",
     "cs-fix": "ts-standard --fix",

--- a/src/_index.node.ts
+++ b/src/_index.node.ts
@@ -1,0 +1,8 @@
+export * as Types from './types'
+export * as Enums from './enums'
+export * as SPDX from './SPDX'
+export * as Models from './models'
+export * as Factories from './factories'
+export * as Spec from './spec'
+export * as Serialize from './serialize/_index.node'
+// do not export the helpers, they are for internal use only

--- a/src/_index.web.ts
+++ b/src/_index.web.ts
@@ -4,5 +4,5 @@ export * as SPDX from './SPDX'
 export * as Models from './models'
 export * as Factories from './factories'
 export * as Spec from './spec'
-export * as Serialize from './serialize'
+export * as Serialize from './serialize/_index.web'
 // do not export the helpers, they are for internal use only

--- a/src/serialize/XmlSerializer.web.ts
+++ b/src/serialize/XmlSerializer.web.ts
@@ -5,9 +5,8 @@ import { SimpleXml } from './XML/types'
 
 /**
  * XML serializer for web browsers.
- * @TODO this class is not final, unclear if it should be part of this dist.
  */
-export class XmlSerializerForWebBrowser extends XmlBaseSerializer {
+export class XmlSerializer extends XmlBaseSerializer {
   protected _serialize (
     normalizedBom: SimpleXml.Element,
     options: SerializerOptions = {}

--- a/src/serialize/_index.node.ts
+++ b/src/serialize/_index.node.ts
@@ -1,0 +1,7 @@
+export * from './'
+
+export * from './JsonSerializer'
+
+// There is no general serializer, as node lacks global XML support.
+// Therefore, a BaseSerializer for XML is published
+export * from './XmlBaseSerializer'

--- a/src/serialize/_index.web.ts
+++ b/src/serialize/_index.web.ts
@@ -1,0 +1,4 @@
+export * from './'
+
+export * from './JsonSerializer'
+export * from './XmlSerializer.web'

--- a/src/serialize/index.ts
+++ b/src/serialize/index.ts
@@ -1,11 +1,9 @@
+// not everything is public, yet
+
 export * as Types from './types'
 
 export * from './BomRefDiscriminator'
 export * from './BaseSerializer'
 
 export * as JSON from './JSON'
-export * from './JsonSerializer'
-
 export * as XML from './XML'
-export * from './XmlBaseSerializer'
-// export * from './XmlSerializer.web' // not public, yet

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "files": ["src/_index.node.ts"],
+  "exclude": [
+    "src/**/*.web.ts"
+  ]
+}

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "files": ["src/_index.web.ts"],
+  "exclude": [
+    "src/**/*.node.ts"
+  ]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ const configBase = {
         loader: 'ts-loader',
         // see https://github.com/TypeStrong/ts-loader
         options: {
+          configFile: 'tsconfig.web.json',
           compilerOptions: {
             // in here parts of typescript compiler can be overridden
           }
@@ -23,7 +24,7 @@ const configBase = {
   resolve: {
     extensions: ['.tsx', '.ts']
   },
-  entry: path.resolve(__dirname, 'src/index.ts'),
+  entry: path.resolve(__dirname, 'src/_index.web.ts'),
   output: {
     path: path.resolve(__dirname, 'dist.web'),
     // filename: '',


### PR DESCRIPTION
just one option to split the builds by target.
alternative to #40