### PR TITLE
`BaseSerializer`'s TemplateType `NormalizedBom` defaults to `any` now.

### DIFF
--- a/src/serialize/baseSerializer.ts
+++ b/src/serialize/baseSerializer.ts
@@ -21,7 +21,7 @@ import { Bom, BomRef } from '../models'
 import { BomRefDiscriminator } from './bomRefDiscriminator'
 import { NormalizerOptions, Serializer, SerializerOptions } from './types'
 
-export abstract class BaseSerializer<NormalizedBom> implements Serializer {
+export abstract class BaseSerializer<NormalizedBom=any> implements Serializer {
   serialize (bom: Bom, options?: SerializerOptions & NormalizerOptions): string {
     const bomRefDiscriminator = new BomRefDiscriminator(this.#getAllBomRefs(bom))
     try {


### PR DESCRIPTION
this allowes the use of the AbstractBaseClass as it was an Interface.
Only the implementations actually care for the `NormalizedBom` - which is ily used internally in protected functions ,,,,.

example usage
```javascript
function f (serializer: BaseSerializer, bom: Bom): any {
  return { source: () => serializer.serialize(bom, serializeOptions) }
}
```

instead of 
```javascript
function f (serializer: BaseSerializer<any>, bom: Bom): any {
  return { source: () => serializer.serialize(bom, serializeOptions) }
}
```