### PR TITLE
docs: add comment to the `compare` methods

### DIFF
--- a/src/helpers/sortableSet.ts
+++ b/src/helpers/sortableSet.ts
@@ -18,11 +18,12 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
 export interface Comparable {
+  // The purpose of this method is not to test for equality, but have deterministic comparability.
   compare: (other: any) => number
 }
 
 export abstract class SortableSet<T extends Comparable> extends Set<T> {
   sorted (): T[] {
-    return Array.from(this).sort((a, b) => a.compare(b))
+    return Array.from(this).sort((a: T, b: T) => a.compare(b))
   }
 }

--- a/src/models/component.ts
+++ b/src/models/component.ts
@@ -115,6 +115,7 @@ export class Component implements Comparable {
   }
 
   compare (other: Component): number {
+    // The purpose of this method is not to test for equality, but have deterministic comparability.
     const bomRefCompare = this.bomRef.compare(other.bomRef)
     if (bomRefCompare !== 0) {
       return bomRefCompare

--- a/src/models/externalReference.ts
+++ b/src/models/externalReference.ts
@@ -36,6 +36,7 @@ export class ExternalReference implements Comparable {
   }
 
   compare (other: ExternalReference): number {
+    // The purpose of this method is not to test for equality, but have deterministic comparability.
     /* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- run compares in weighted order */
     return this.type.localeCompare(other.type) ||
       this.url.toString().localeCompare(other.url.toString())

--- a/src/models/tool.ts
+++ b/src/models/tool.ts
@@ -45,6 +45,7 @@ export class Tool implements Comparable {
   }
 
   compare (other: Tool): number {
+    // The purpose of this method is not to test for equality, but have deterministic comparability.
     /* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- run compares in weighted order */
     return (this.vendor ?? '').localeCompare(other.vendor ?? '') ||
       (this.name ?? '').localeCompare(other.name ?? '') ||


### PR DESCRIPTION
purpose: make the implementation and the purpose of `compare` clearer