### PR TITLE
distribute commonjs and esm in paralle/hybrid

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -171,5 +171,7 @@ dist
 
 /examples/
 
+/scripts/
+
 /reports/
 /CI_reports/

--- a/package.json
+++ b/package.json
@@ -58,14 +58,18 @@
     "webpack-cli": "4.10.0",
     "xmlbuilder2": "^3.0.2"
   },
-  "browser": "./dist.web/lib.js",
+  "browser": "./dist/web/lib.js",
   "types": "./src/index.node.ts",
-  "main": "./dist.node/index.node.js",
-  "exports": "./dist.node/index.node.js",
+  "main": "./dist.node.commonjs/index.node.cjs",
+  "exports": {
+    ".": {
+      "import": "./dist.node.esm/index.node.mjs",
+      "require": "./dist.node.commonjs/index.node.cjs"
+    }
+  },
   "directories": {
     "doc": "./docs",
     "src": "./src",
-    "lib": "./dist.node",
     "test": "./tests",
     "example": "./examples"
   },
@@ -73,9 +77,14 @@
     "prepublish": "npm run build",
     "prepublishOnly": "npm run build",
     "lint": "tsc --noEmit",
-    "build": "run-p --aggregate-output -l build:*",
-    "prebuild:node": "node -r fs -e 'fs.rmSync(\"dist.node\",{recursive:true,force:true})'",
-    "build:node": "tsc -b ./tsconfig.node.json",
+    "build": "run-p --aggregate-output -lc build:*",
+    "build:node": "run-p --aggregate-output -lc build:node:*",
+    "prebuild:node:commonjs": "node -r fs -e 'fs.rmSync(\"dist.node.commonjs\",{recursive:true,force:true})'",
+    "build:node:commonjs": "tsc -b ./tsconfig.node.commonjs.json",
+    "postbuild:node:commonjs": "node scripts/rename-dist.js dist.node.commonjs cjs",
+    "prebuild:node:esm": "node -r fs -e 'fs.rmSync(\"dist.node.esm\",{recursive:true,force:true})'",
+    "build:node:esm": "tsc -b ./tsconfig.node.esm.json",
+    "postbuild:node:esm": "node scripts/rename-dist.js dist.node.esm mjs",
     "prebuild:web": "node -r fs -e 'fs.rmSync(\"dist.web\",{recursive:true,force:true})'",
     "build:web": "webpack build",
     "cs-fix": "eslint --fix .",

--- a/scripts/rename-dist.js
+++ b/scripts/rename-dist.js
@@ -1,0 +1,56 @@
+'use strict'
+/*!
+This file is part of CycloneDX JavaScript Library.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) OWASP Foundation. All Rights Reserved.
+*/
+
+const { statSync, renameSync, readdirSync } = require('fs')
+const { resolve } = require('path')
+
+/**
+ * @param {string} dir
+ */
+function replace (dir) {
+  // console.log('>> ', dir)
+  for (const _ of readdirSync(dir)) {
+    const entry = resolve(dir, _)
+    const stats = statSync(entry)
+    if (stats.isDirectory()) {
+      replace(entry)
+    } else if (stats.isFile()) {
+      if (srcExtRE.test(entry)) {
+        const renamed = entry.replace(srcExtRE, `.${targetExt}`)
+        renameSync(entry, renamed)
+        // console.log(entry, ' -> ', renamed)
+      }
+    }
+  }
+}
+
+const srcExt = 'js'
+const dir = process.argv[2]
+const targetExt = process.argv[3]
+
+// console.log('dir', dir)
+// console.log('targetExt', targetExt)
+
+if (!dir) { process.exit(1) }
+if (!targetExt) { process.exit(2) }
+
+const srcExtRE = new RegExp(`\\.${srcExt}$`, 'i')
+
+replace(resolve(process.cwd(), dir))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
 
     /* Modules */
     /* check compat: https://node.green/ */
-    "module": "CommonJS",                                /* Specify what module code is generated. */
+    // "module": "CommonJS",                                /* Specify what module code is generated. */
     "rootDir": "src",                               /* Specify the root folder within your source files. */
     "moduleResolution": "Node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */

--- a/tsconfig.node.commonjs.json
+++ b/tsconfig.node.commonjs.json
@@ -3,6 +3,8 @@
   "extends": "./tsconfig.json",
   "files": ["src/index.node.ts"],
   "compilerOptions": {
-    "outDir": "./dist.node/"
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "./dist.node.commonjs/"
   }
 }

--- a/tsconfig.node.esm.json
+++ b/tsconfig.node.esm.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "files": ["src/index.node.ts"],
+  "compilerOptions": {
+    "module": "ES6",
+    "moduleResolution": "Node",
+    "outDir": "./dist.node.esm/"
+  }
+}

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./tsconfig.json",
-  "files": ["src/index.web.ts"]
+  "files": ["src/index.web.ts"],
+  "compilerOptions": {
+    "module": "CommonJS"
+  }
 }


### PR DESCRIPTION
part of  #18
in contrast to #213

----


use `rollup` to build files <https://www.npmjs.com/package/rollup>

- [ ] built commonJS  (cjs)
- [ ] built ES6 module (esm/mjs) 
- [ ] have a test use cjs   - and pass 
- [ ] have a test use mjs - and pass 