### PR TITLE
fix: `Types.isCPE()` CPE2.3 with escaped chars `&"><` are allowed

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+## 1.0.3 - 2022-07-28
+
+* Fixed
+  * `Types.isCPE()` for CPE2.3 allows escaped(`\`) chars `&"><`, as expected. (via [#132])
+
+[#132]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/132
+
 ## 1.0.2 - 2022-07-26
 
 Maintenance release.

--- a/src/types/cpe.ts
+++ b/src/types/cpe.ts
@@ -24,8 +24,8 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 export type CPE = string
 
-/* eslint-disable-next-line no-useless-escape -- value directly from XML or JSON spec, surrounded with ^$ */
-const cpePattern = /^([c][pP][eE]:\/[AHOaho]?(:[A-Za-z0-9\._\-~%]*){0,6})$|^(cpe:2\.3:[aho\*\-](:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!&quot;#$$%&amp;'\(\)\+,\/:;&lt;=&gt;@\[\]\^`\{\|}~]))+(\?*|\*?))|[\*\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[\*\-]))(:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!&quot;#$$%&amp;'\(\)\+,\/:;&lt;=&gt;@\[\]\^`\{\|}~]))+(\?*|\*?))|[\*\-])){4})$/
+/* eslint-disable-next-line no-useless-escape -- value directly from XML, revert special-chars(like `&amp;` -> `&`), and surrounded with `^` and `$` */
+const cpePattern = /^([c][pP][eE]:\/[AHOaho]?(:[A-Za-z0-9\._\-~%]*){0,6})$|^(cpe:2\.3:[aho\*\-](:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!"#$$%&'\(\)\+,\/:;<=>@\[\]\^`\{\|}~]))+(\?*|\*?))|[\*\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[\*\-]))(:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!"#$$%&'\(\)\+,\/:;<=>@\[\]\^`\{\|}~]))+(\?*|\*?))|[\*\-])){4})$/
 
 export function isCPE (value: any): value is CPE {
   return typeof value === 'string' &&

--- a/tests/unit/Types/cpe.spec.js
+++ b/tests/unit/Types/cpe.spec.js
@@ -1,0 +1,47 @@
+'use strict'
+/*!
+This file is part of CycloneDX JavaScript Library.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) OWASP Foundation. All Rights Reserved.
+*/
+
+const assert = require('assert')
+const { suite, test } = require('mocha')
+
+const {
+  Types: { isCPE }
+} = require('../../../')
+
+suite('Types.cpe', () => {
+  suite('isCPE()', () => {
+    test('2.2', () => {
+      const actual = isCPE('cpe:/a:microsoft:internet_explorer:11:-')
+      assert.strictEqual(actual, true)
+    })
+    test('2.3', () => {
+      const actual = isCPE('cpe:2.3:a:adobe:flash_player:19.0.0.245:*:*:*:*:internet_explorer:*:*')
+      assert.strictEqual(actual, true)
+    })
+    test('reverted XML special-chars', () => {
+      // pattern is taken from XML.
+      // XML encodes some chars - like '"` -> `&quot;` or `&` -> `&amp;`.
+      // this encoding must have been reverted for the RegularExpression.
+      // use case: test if the CPE-escaped(`\`) chars are working as expected
+      const actual = isCPE('cpe:2.3:a:acme:foobarbaz:1.3.3.7:*:*:*:\\":\\&:\\>:\\<')
+      assert.strictEqual(actual, true)
+    })
+  })
+})


### PR DESCRIPTION
- [x] implemented the fix
- [x] implemented unit tests and regression test