### PR TITLE
add support for sub-components (`Models.Component.components`)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## unreleased
 
 * Added
-  * Support for nested/bundled components via `Models.Component.components` as added, including
+  * Support for nested/bundled components via `Models.Component.components` was added, including
     serialization/normalization of models and impact on dependency graphs rendering. ([#132] via [#136])
   * CycloneDX spec version 1.4 made element `Models.Component.version` optional.
     Therefore, serialization/normalization with this spec version will no longer render this element

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,10 +5,13 @@ All notable changes to this project will be documented in this file.
 ## unreleased
 
 * Added
+  * Implemented support for nested/bundled components via `bom.component.components`. ([#132] via [#136])
   * CycloneDX spec version 1.4 made element `bom.component.version` optional.  
     Therefore, serialization/normalization with this spec version will no longer render this element,
     when its value is empty. (via [#137], [#138])
 
+[#132]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/132
+[#136]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/136
 [#137]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/137
 [#138]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/138
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## unreleased
 
 * Added
-  * Support for nested/bundled components via `Models.Component.components` was added, including
+  * Support for nested/bundled (sub-)components via `Models.Component.components` was added, including
     serialization/normalization of models and impact on dependency graphs rendering. ([#132] via [#136])
   * CycloneDX spec version 1.4 made element `Models.Component.version` optional.
     Therefore, serialization/normalization with this spec version will no longer render this element

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 ## unreleased
 
 * Added
-  * Support for nested/bundled components via `bom.component.components` as added,
-    including normalization of models and extended integration in possible dependency graph. ([#132] via [#136])
-  * CycloneDX spec version 1.4 made element `bom.component.version` optional.  
-    Therefore, serialization/normalization with this spec version will no longer render this element,
-    when its value is empty. (via [#137], [#138])
+  * Support for nested/bundled components via `Models.Component.components` as added, including
+    serialization/normalization of models and impact on dependency graphs rendering. ([#132] via [#136])
+  * CycloneDX spec version 1.4 made element `Models.Component.version` optional.
+    Therefore, serialization/normalization with this spec version will no longer render this element
+    if its value is empty. (via [#137], [#138])
 
 [#132]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/132
 [#136]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/136

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 ## unreleased
 
 * Added
-  * Implemented support for nested/bundled components via `bom.component.components`. ([#132] via [#136])
+  * Support for nested/bundled components via `bom.component.components` as added,
+    including normalization of models and extended integration in possible dependency graph. ([#132] via [#136])
   * CycloneDX spec version 1.4 made element `bom.component.version` optional.  
     Therefore, serialization/normalization with this spec version will no longer render this element,
     when its value is empty. (via [#137], [#138])

--- a/src/helpers/tree.ts
+++ b/src/helpers/tree.ts
@@ -1,0 +1,20 @@
+/*!
+This file is part of CycloneDX JavaScript Library.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) OWASP Foundation. All Rights Reserved.
+*/
+
+export const treeIterator = Symbol('iterator of a tree/nesting-like structure')

--- a/src/models/component.ts
+++ b/src/models/component.ts
@@ -28,6 +28,7 @@ import { ExternalReferenceRepository } from './externalReference'
 import { LicenseRepository } from './license'
 import { SWID } from './swid'
 import { Comparable, SortableSet } from '../helpers/sortableSet'
+import { treeIterator } from '../helpers/tree'
 
 interface OptionalProperties {
   bomRef?: BomRef['value']
@@ -137,4 +138,10 @@ export class Component implements Comparable {
 }
 
 export class ComponentRepository extends SortableSet<Component> {
+  * [treeIterator] (): Generator<Component> {
+    for (const component of this) {
+      yield component
+      yield * component.components[treeIterator]()
+    }
+  }
 }

--- a/src/models/component.ts
+++ b/src/models/component.ts
@@ -45,6 +45,7 @@ interface OptionalProperties {
   swid?: Component['swid']
   version?: Component['version']
   dependencies?: Component['dependencies']
+  components?: Component['components']
   cpe?: Component['cpe']
 }
 
@@ -65,6 +66,7 @@ export class Component implements Comparable {
   swid?: SWID
   version?: string
   dependencies: BomRefRepository
+  components: ComponentRepository
 
   /** @see bomRef */
   readonly #bomRef: BomRef
@@ -93,6 +95,7 @@ export class Component implements Comparable {
     this.version = op.version
     this.description = op.description
     this.dependencies = op.dependencies ?? new BomRefRepository()
+    this.components = op.components ?? new ComponentRepository()
     this.cpe = op.cpe
   }
 

--- a/src/serialize/json/normalize.ts
+++ b/src/serialize/json/normalize.ts
@@ -403,7 +403,7 @@ export class DependencyGraphNormalizer extends Base {
       }
     }
     for (const component of data.components[treeIterator]()) {
-      allRefs.set(component.bomRef, new Models.BomRefRepository(component.dependencies))
+      allRefs.set(component.bomRef, component.dependencies)
     }
 
     const normalized: Normalized.Dependency[] = []

--- a/src/serialize/json/normalize.ts
+++ b/src/serialize/json/normalize.ts
@@ -23,6 +23,7 @@ import * as Models from '../../models'
 import { Protocol as Spec, Version as SpecVersion } from '../../spec'
 import { NormalizerOptions } from '../types'
 import { JsonSchema, Normalized } from './types'
+import { treeIterator } from '../../helpers/tree'
 
 export class Factory {
   readonly #spec: Spec
@@ -397,9 +398,12 @@ export class DependencyGraphNormalizer extends Base {
     const allRefs = new Map<Models.BomRef, Models.BomRefRepository>()
     if (data.metadata.component !== undefined) {
       allRefs.set(data.metadata.component.bomRef, data.metadata.component.dependencies)
+      for (const component of data.metadata.component.components[treeIterator]()) {
+        allRefs.set(component.bomRef, component.dependencies)
+      }
     }
-    for (const c of data.components) {
-      allRefs.set(c.bomRef, new Models.BomRefRepository(c.dependencies))
+    for (const component of data.components[treeIterator]()) {
+      allRefs.set(component.bomRef, new Models.BomRefRepository(component.dependencies))
     }
 
     const normalized: Normalized.Dependency[] = []

--- a/src/serialize/json/normalize.ts
+++ b/src/serialize/json/normalize.ts
@@ -270,6 +270,9 @@ export class ComponentNormalizer extends Base {
             : this._factory.makeForSWID().normalize(data.swid, options),
           externalReferences: data.externalReferences.size > 0
             ? this._factory.makeForExternalReference().normalizeRepository(data.externalReferences, options)
+            : undefined,
+          components: data.components.size > 0
+            ? this.normalizeRepository(data.components, options)
             : undefined
         }
       : undefined

--- a/src/serialize/xml/normalize.ts
+++ b/src/serialize/xml/normalize.ts
@@ -519,11 +519,11 @@ export class DependencyGraphNormalizer extends Base {
     if (data.metadata.component !== undefined) {
       allRefs.set(data.metadata.component.bomRef, data.metadata.component.dependencies)
       for (const component of data.metadata.component.components[treeIterator]()) {
-        allRefs.set(component.bomRef, new Models.BomRefRepository(component.dependencies))
+        allRefs.set(component.bomRef, component.dependencies)
       }
     }
     for (const component of data.components[treeIterator]()) {
-      allRefs.set(component.bomRef, new Models.BomRefRepository(component.dependencies))
+      allRefs.set(component.bomRef, component.dependencies)
     }
 
     const normalized: Array<(SimpleXml.Element & { attributes: { ref: string } })> = []

--- a/src/serialize/xml/normalize.ts
+++ b/src/serialize/xml/normalize.ts
@@ -23,6 +23,7 @@ import * as Models from '../../models'
 import { Protocol as Spec, Version as SpecVersion } from '../../spec'
 import { NormalizerOptions } from '../types'
 import { SimpleXml, XmlSchema } from './types'
+import { treeIterator } from '../../helpers/tree'
 
 export class Factory {
   readonly #spec: Spec
@@ -517,9 +518,12 @@ export class DependencyGraphNormalizer extends Base {
     const allRefs = new Map<Models.BomRef, Models.BomRefRepository>()
     if (data.metadata.component !== undefined) {
       allRefs.set(data.metadata.component.bomRef, data.metadata.component.dependencies)
+      for (const component of data.metadata.component.components[treeIterator]()) {
+        allRefs.set(component.bomRef, new Models.BomRefRepository(component.dependencies))
+      }
     }
-    for (const c of data.components) {
-      allRefs.set(c.bomRef, new Models.BomRefRepository(c.dependencies))
+    for (const component of data.components[treeIterator]()) {
+      allRefs.set(component.bomRef, new Models.BomRefRepository(component.dependencies))
     }
 
     const normalized: Array<(SimpleXml.Element & { attributes: { ref: string } })> = []

--- a/src/serialize/xml/normalize.ts
+++ b/src/serialize/xml/normalize.ts
@@ -335,6 +335,13 @@ export class ComponentNormalizer extends Base {
             .normalizeRepository(data.externalReferences, options, 'reference')
         }
       : undefined
+    const components: SimpleXml.Element | undefined = data.components.size > 0
+      ? {
+          type: 'element',
+          name: 'components',
+          children: this.normalizeRepository(data.components, options, 'component')
+        }
+      : undefined
     return {
       type: 'element',
       name: elementName,
@@ -357,7 +364,8 @@ export class ComponentNormalizer extends Base {
         makeOptionalTextElement(data.cpe, 'cpe'),
         makeOptionalTextElement(data.purl, 'purl'),
         swid,
-        extRefs
+        extRefs,
+        components
       ].filter(isNotUndefined)
     }
   }

--- a/tests/_data/models.js
+++ b/tests/_data/models.js
@@ -177,6 +177,9 @@ module.exports.createComplexStructure = function () {
     })
     subComponentA.dependencies.add(subComponentB.bomRef)
     component.components.add(subComponentB)
+
+    bom.metadata.component.dependencies.add(component.bomRef)
+
     return component
   })(new Models.Component(
     Enums.ComponentType.Framework, 'SomeFrameworkBundle', {

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.2.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.2.json
@@ -161,6 +161,26 @@
           "comment": "testing"
         }
       ]
+    },
+    {
+      "type": "framework",
+      "name": "SomeFrameworkBundle",
+      "version": "",
+      "bom-ref": "SomeFrameworkBundle",
+      "components": [
+        {
+          "type": "library",
+          "name": "SubComponentA",
+          "version": "",
+          "bom-ref": "SomeFrameworkBundle#SubComponentA"
+        },
+        {
+          "type": "library",
+          "name": "SubComponentB",
+          "version": "",
+          "bom-ref": "SomeFrameworkBundle#SubComponentB"
+        }
+      ]
     }
   ],
   "dependencies": [
@@ -179,6 +199,9 @@
         "a-component",
         "dummy-component"
       ]
+    },
+    {
+      "ref": "SomeFrameworkBundle"
     }
   ]
 }

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.2.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.2.json
@@ -202,7 +202,19 @@
       ]
     },
     {
-      "ref": "SomeFrameworkBundle"
+      "ref": "SomeFrameworkBundle",
+      "dependsOn": [
+        "SomeFrameworkBundle#SubComponentA"
+      ]
+    },
+    {
+      "ref": "SomeFrameworkBundle#SubComponentA",
+      "dependsOn": [
+        "SomeFrameworkBundle#SubComponentB"
+      ]
+    },
+    {
+      "ref": "SomeFrameworkBundle#SubComponentB"
     }
   ]
 }

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.2.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.2.json
@@ -197,7 +197,8 @@
       "ref": "dummy.metadata.component",
       "dependsOn": [
         "a-component",
-        "dummy-component"
+        "dummy-component",
+        "SomeFrameworkBundle"
       ]
     },
     {

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.3.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.3.json
@@ -161,6 +161,26 @@
           "comment": "testing"
         }
       ]
+    },
+    {
+      "type": "framework",
+      "name": "SomeFrameworkBundle",
+      "version": "",
+      "bom-ref": "SomeFrameworkBundle",
+      "components": [
+        {
+          "type": "library",
+          "name": "SubComponentA",
+          "version": "",
+          "bom-ref": "SomeFrameworkBundle#SubComponentA"
+        },
+        {
+          "type": "library",
+          "name": "SubComponentB",
+          "version": "",
+          "bom-ref": "SomeFrameworkBundle#SubComponentB"
+        }
+      ]
     }
   ],
   "dependencies": [
@@ -179,6 +199,9 @@
         "a-component",
         "dummy-component"
       ]
+    },
+    {
+      "ref": "SomeFrameworkBundle"
     }
   ]
 }

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.3.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.3.json
@@ -202,7 +202,19 @@
       ]
     },
     {
-      "ref": "SomeFrameworkBundle"
+      "ref": "SomeFrameworkBundle",
+      "dependsOn": [
+        "SomeFrameworkBundle#SubComponentA"
+      ]
+    },
+    {
+      "ref": "SomeFrameworkBundle#SubComponentA",
+      "dependsOn": [
+        "SomeFrameworkBundle#SubComponentB"
+      ]
+    },
+    {
+      "ref": "SomeFrameworkBundle#SubComponentB"
     }
   ]
 }

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.3.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.3.json
@@ -197,7 +197,8 @@
       "ref": "dummy.metadata.component",
       "dependsOn": [
         "a-component",
-        "dummy-component"
+        "dummy-component",
+        "SomeFrameworkBundle"
       ]
     },
     {

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.4.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.4.json
@@ -208,7 +208,19 @@
       ]
     },
     {
-      "ref": "SomeFrameworkBundle"
+      "ref": "SomeFrameworkBundle",
+      "dependsOn": [
+        "SomeFrameworkBundle#SubComponentA"
+      ]
+    },
+    {
+      "ref": "SomeFrameworkBundle#SubComponentA",
+      "dependsOn": [
+        "SomeFrameworkBundle#SubComponentB"
+      ]
+    },
+    {
+      "ref": "SomeFrameworkBundle#SubComponentB"
     }
   ]
 }

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.4.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.4.json
@@ -203,7 +203,8 @@
       "ref": "dummy.metadata.component",
       "dependsOn": [
         "a-component",
-        "dummy-component"
+        "dummy-component",
+        "SomeFrameworkBundle"
       ]
     },
     {

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.4.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.4.json
@@ -170,6 +170,23 @@
           "comment": "testing"
         }
       ]
+    },
+    {
+      "type": "framework",
+      "name": "SomeFrameworkBundle",
+      "bom-ref": "SomeFrameworkBundle",
+      "components": [
+        {
+          "type": "library",
+          "name": "SubComponentA",
+          "bom-ref": "SomeFrameworkBundle#SubComponentA"
+        },
+        {
+          "type": "library",
+          "name": "SubComponentB",
+          "bom-ref": "SomeFrameworkBundle#SubComponentB"
+        }
+      ]
     }
   ],
   "dependencies": [
@@ -188,6 +205,9 @@
         "a-component",
         "dummy-component"
       ]
+    },
+    {
+      "ref": "SomeFrameworkBundle"
     }
   ]
 }

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.2.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.2.json
@@ -612,6 +612,38 @@
           "attributes": {
             "ref": "SomeFrameworkBundle"
           },
+          "children": [
+            {
+              "type": "element",
+              "name": "dependency",
+              "attributes": {
+                "ref": "SomeFrameworkBundle#SubComponentA"
+              }
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "dependency",
+          "attributes": {
+            "ref": "SomeFrameworkBundle#SubComponentA"
+          },
+          "children": [
+            {
+              "type": "element",
+              "name": "dependency",
+              "attributes": {
+                "ref": "SomeFrameworkBundle#SubComponentB"
+              }
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "dependency",
+          "attributes": {
+            "ref": "SomeFrameworkBundle#SubComponentB"
+          },
           "children": []
         }
       ]

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.2.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.2.json
@@ -596,6 +596,13 @@
               "attributes": {
                 "ref": "dummy-component"
               }
+            },
+            {
+              "type": "element",
+              "name": "dependency",
+              "attributes": {
+                "ref": "SomeFrameworkBundle"
+              }
             }
           ]
         },

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.2.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.2.json
@@ -479,6 +479,72 @@
               ]
             }
           ]
+        },
+        {
+          "type": "element",
+          "name": "component",
+          "attributes": {
+            "type": "framework",
+            "bom-ref": "SomeFrameworkBundle"
+          },
+          "children": [
+            {
+              "type": "element",
+              "name": "name",
+              "children": "SomeFrameworkBundle"
+            },
+            {
+              "type": "element",
+              "name": "version",
+              "children": ""
+            },
+            {
+              "type": "element",
+              "name": "components",
+              "children": [
+                {
+                  "type": "element",
+                  "name": "component",
+                  "attributes": {
+                    "type": "library",
+                    "bom-ref": "SomeFrameworkBundle#SubComponentA"
+                  },
+                  "children": [
+                    {
+                      "type": "element",
+                      "name": "name",
+                      "children": "SubComponentA"
+                    },
+                    {
+                      "type": "element",
+                      "name": "version",
+                      "children": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "component",
+                  "attributes": {
+                    "type": "library",
+                    "bom-ref": "SomeFrameworkBundle#SubComponentB"
+                  },
+                  "children": [
+                    {
+                      "type": "element",
+                      "name": "name",
+                      "children": "SubComponentB"
+                    },
+                    {
+                      "type": "element",
+                      "name": "version",
+                      "children": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -532,6 +598,14 @@
               }
             }
           ]
+        },
+        {
+          "type": "element",
+          "name": "dependency",
+          "attributes": {
+            "ref": "SomeFrameworkBundle"
+          },
+          "children": []
         }
       ]
     }

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.3.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.3.json
@@ -612,6 +612,38 @@
           "attributes": {
             "ref": "SomeFrameworkBundle"
           },
+          "children": [
+            {
+              "type": "element",
+              "name": "dependency",
+              "attributes": {
+                "ref": "SomeFrameworkBundle#SubComponentA"
+              }
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "dependency",
+          "attributes": {
+            "ref": "SomeFrameworkBundle#SubComponentA"
+          },
+          "children": [
+            {
+              "type": "element",
+              "name": "dependency",
+              "attributes": {
+                "ref": "SomeFrameworkBundle#SubComponentB"
+              }
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "dependency",
+          "attributes": {
+            "ref": "SomeFrameworkBundle#SubComponentB"
+          },
           "children": []
         }
       ]

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.3.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.3.json
@@ -596,6 +596,13 @@
               "attributes": {
                 "ref": "dummy-component"
               }
+            },
+            {
+              "type": "element",
+              "name": "dependency",
+              "attributes": {
+                "ref": "SomeFrameworkBundle"
+              }
             }
           ]
         },

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.3.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.3.json
@@ -479,6 +479,72 @@
               ]
             }
           ]
+        },
+        {
+          "type": "element",
+          "name": "component",
+          "attributes": {
+            "type": "framework",
+            "bom-ref": "SomeFrameworkBundle"
+          },
+          "children": [
+            {
+              "type": "element",
+              "name": "name",
+              "children": "SomeFrameworkBundle"
+            },
+            {
+              "type": "element",
+              "name": "version",
+              "children": ""
+            },
+            {
+              "type": "element",
+              "name": "components",
+              "children": [
+                {
+                  "type": "element",
+                  "name": "component",
+                  "attributes": {
+                    "type": "library",
+                    "bom-ref": "SomeFrameworkBundle#SubComponentA"
+                  },
+                  "children": [
+                    {
+                      "type": "element",
+                      "name": "name",
+                      "children": "SubComponentA"
+                    },
+                    {
+                      "type": "element",
+                      "name": "version",
+                      "children": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "component",
+                  "attributes": {
+                    "type": "library",
+                    "bom-ref": "SomeFrameworkBundle#SubComponentB"
+                  },
+                  "children": [
+                    {
+                      "type": "element",
+                      "name": "name",
+                      "children": "SubComponentB"
+                    },
+                    {
+                      "type": "element",
+                      "name": "version",
+                      "children": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -532,6 +598,14 @@
               }
             }
           ]
+        },
+        {
+          "type": "element",
+          "name": "dependency",
+          "attributes": {
+            "ref": "SomeFrameworkBundle"
+          },
+          "children": []
         }
       ]
     }

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.4.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.4.json
@@ -610,6 +610,13 @@
               "attributes": {
                 "ref": "dummy-component"
               }
+            },
+            {
+              "type": "element",
+              "name": "dependency",
+              "attributes": {
+                "ref": "SomeFrameworkBundle"
+              }
             }
           ]
         },

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.4.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.4.json
@@ -626,6 +626,38 @@
           "attributes": {
             "ref": "SomeFrameworkBundle"
           },
+          "children": [
+            {
+              "type": "element",
+              "name": "dependency",
+              "attributes": {
+                "ref": "SomeFrameworkBundle#SubComponentA"
+              }
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "dependency",
+          "attributes": {
+            "ref": "SomeFrameworkBundle#SubComponentA"
+          },
+          "children": [
+            {
+              "type": "element",
+              "name": "dependency",
+              "attributes": {
+                "ref": "SomeFrameworkBundle#SubComponentB"
+              }
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "dependency",
+          "attributes": {
+            "ref": "SomeFrameworkBundle#SubComponentB"
+          },
           "children": []
         }
       ]

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.4.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.4.json
@@ -508,6 +508,57 @@
               ]
             }
           ]
+        },
+        {
+          "type": "element",
+          "name": "component",
+          "attributes": {
+            "type": "framework",
+            "bom-ref": "SomeFrameworkBundle"
+          },
+          "children": [
+            {
+              "type": "element",
+              "name": "name",
+              "children": "SomeFrameworkBundle"
+            },
+            {
+              "type": "element",
+              "name": "components",
+              "children": [
+                {
+                  "type": "element",
+                  "name": "component",
+                  "attributes": {
+                    "type": "library",
+                    "bom-ref": "SomeFrameworkBundle#SubComponentA"
+                  },
+                  "children": [
+                    {
+                      "type": "element",
+                      "name": "name",
+                      "children": "SubComponentA"
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "component",
+                  "attributes": {
+                    "type": "library",
+                    "bom-ref": "SomeFrameworkBundle#SubComponentB"
+                  },
+                  "children": [
+                    {
+                      "type": "element",
+                      "name": "name",
+                      "children": "SubComponentB"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -561,6 +612,14 @@
               }
             }
           ]
+        },
+        {
+          "type": "element",
+          "name": "dependency",
+          "attributes": {
+            "ref": "SomeFrameworkBundle"
+          },
+          "children": []
         }
       ]
     }

--- a/tests/_data/serializeResults/json_complex_spec1.2.json.bin
+++ b/tests/_data/serializeResults/json_complex_spec1.2.json.bin
@@ -202,7 +202,19 @@
             ]
         },
         {
-            "ref": "SomeFrameworkBundle"
+            "ref": "SomeFrameworkBundle",
+            "dependsOn": [
+                "SomeFrameworkBundle#SubComponentA"
+            ]
+        },
+        {
+            "ref": "SomeFrameworkBundle#SubComponentA",
+            "dependsOn": [
+                "SomeFrameworkBundle#SubComponentB"
+            ]
+        },
+        {
+            "ref": "SomeFrameworkBundle#SubComponentB"
         }
     ]
 }

--- a/tests/_data/serializeResults/json_complex_spec1.2.json.bin
+++ b/tests/_data/serializeResults/json_complex_spec1.2.json.bin
@@ -161,6 +161,26 @@
                     "comment": "testing"
                 }
             ]
+        },
+        {
+            "type": "framework",
+            "name": "SomeFrameworkBundle",
+            "version": "",
+            "bom-ref": "SomeFrameworkBundle",
+            "components": [
+                {
+                    "type": "library",
+                    "name": "SubComponentA",
+                    "version": "",
+                    "bom-ref": "SomeFrameworkBundle#SubComponentA"
+                },
+                {
+                    "type": "library",
+                    "name": "SubComponentB",
+                    "version": "",
+                    "bom-ref": "SomeFrameworkBundle#SubComponentB"
+                }
+            ]
         }
     ],
     "dependencies": [
@@ -179,6 +199,9 @@
                 "a-component",
                 "dummy-component"
             ]
+        },
+        {
+            "ref": "SomeFrameworkBundle"
         }
     ]
 }

--- a/tests/_data/serializeResults/json_complex_spec1.2.json.bin
+++ b/tests/_data/serializeResults/json_complex_spec1.2.json.bin
@@ -197,7 +197,8 @@
             "ref": "dummy.metadata.component",
             "dependsOn": [
                 "a-component",
-                "dummy-component"
+                "dummy-component",
+                "SomeFrameworkBundle"
             ]
         },
         {

--- a/tests/_data/serializeResults/json_complex_spec1.3.json.bin
+++ b/tests/_data/serializeResults/json_complex_spec1.3.json.bin
@@ -202,7 +202,19 @@
             ]
         },
         {
-            "ref": "SomeFrameworkBundle"
+            "ref": "SomeFrameworkBundle",
+            "dependsOn": [
+                "SomeFrameworkBundle#SubComponentA"
+            ]
+        },
+        {
+            "ref": "SomeFrameworkBundle#SubComponentA",
+            "dependsOn": [
+                "SomeFrameworkBundle#SubComponentB"
+            ]
+        },
+        {
+            "ref": "SomeFrameworkBundle#SubComponentB"
         }
     ]
 }

--- a/tests/_data/serializeResults/json_complex_spec1.3.json.bin
+++ b/tests/_data/serializeResults/json_complex_spec1.3.json.bin
@@ -161,6 +161,26 @@
                     "comment": "testing"
                 }
             ]
+        },
+        {
+            "type": "framework",
+            "name": "SomeFrameworkBundle",
+            "version": "",
+            "bom-ref": "SomeFrameworkBundle",
+            "components": [
+                {
+                    "type": "library",
+                    "name": "SubComponentA",
+                    "version": "",
+                    "bom-ref": "SomeFrameworkBundle#SubComponentA"
+                },
+                {
+                    "type": "library",
+                    "name": "SubComponentB",
+                    "version": "",
+                    "bom-ref": "SomeFrameworkBundle#SubComponentB"
+                }
+            ]
         }
     ],
     "dependencies": [
@@ -179,6 +199,9 @@
                 "a-component",
                 "dummy-component"
             ]
+        },
+        {
+            "ref": "SomeFrameworkBundle"
         }
     ]
 }

--- a/tests/_data/serializeResults/json_complex_spec1.3.json.bin
+++ b/tests/_data/serializeResults/json_complex_spec1.3.json.bin
@@ -197,7 +197,8 @@
             "ref": "dummy.metadata.component",
             "dependsOn": [
                 "a-component",
-                "dummy-component"
+                "dummy-component",
+                "SomeFrameworkBundle"
             ]
         },
         {

--- a/tests/_data/serializeResults/json_complex_spec1.4.json.bin
+++ b/tests/_data/serializeResults/json_complex_spec1.4.json.bin
@@ -203,7 +203,8 @@
             "ref": "dummy.metadata.component",
             "dependsOn": [
                 "a-component",
-                "dummy-component"
+                "dummy-component",
+                "SomeFrameworkBundle"
             ]
         },
         {

--- a/tests/_data/serializeResults/json_complex_spec1.4.json.bin
+++ b/tests/_data/serializeResults/json_complex_spec1.4.json.bin
@@ -208,7 +208,19 @@
             ]
         },
         {
-            "ref": "SomeFrameworkBundle"
+            "ref": "SomeFrameworkBundle",
+            "dependsOn": [
+                "SomeFrameworkBundle#SubComponentA"
+            ]
+        },
+        {
+            "ref": "SomeFrameworkBundle#SubComponentA",
+            "dependsOn": [
+                "SomeFrameworkBundle#SubComponentB"
+            ]
+        },
+        {
+            "ref": "SomeFrameworkBundle#SubComponentB"
         }
     ]
 }

--- a/tests/_data/serializeResults/json_complex_spec1.4.json.bin
+++ b/tests/_data/serializeResults/json_complex_spec1.4.json.bin
@@ -170,6 +170,23 @@
                     "comment": "testing"
                 }
             ]
+        },
+        {
+            "type": "framework",
+            "name": "SomeFrameworkBundle",
+            "bom-ref": "SomeFrameworkBundle",
+            "components": [
+                {
+                    "type": "library",
+                    "name": "SubComponentA",
+                    "bom-ref": "SomeFrameworkBundle#SubComponentA"
+                },
+                {
+                    "type": "library",
+                    "name": "SubComponentB",
+                    "bom-ref": "SomeFrameworkBundle#SubComponentB"
+                }
+            ]
         }
     ],
     "dependencies": [
@@ -188,6 +205,9 @@
                 "a-component",
                 "dummy-component"
             ]
+        },
+        {
+            "ref": "SomeFrameworkBundle"
         }
     ]
 }

--- a/tests/_data/serializeResults/xml_complex_spec1.2.xml.bin
+++ b/tests/_data/serializeResults/xml_complex_spec1.2.xml.bin
@@ -131,6 +131,12 @@
             <dependency ref="dummy-component"/>
             <dependency ref="SomeFrameworkBundle"/>
         </dependency>
-        <dependency ref="SomeFrameworkBundle"/>
+        <dependency ref="SomeFrameworkBundle">
+            <dependency ref="SomeFrameworkBundle#SubComponentA"/>
+        </dependency>
+        <dependency ref="SomeFrameworkBundle#SubComponentA">
+            <dependency ref="SomeFrameworkBundle#SubComponentB"/>
+        </dependency>
+        <dependency ref="SomeFrameworkBundle#SubComponentB"/>
     </dependencies>
 </bom>

--- a/tests/_data/serializeResults/xml_complex_spec1.2.xml.bin
+++ b/tests/_data/serializeResults/xml_complex_spec1.2.xml.bin
@@ -129,6 +129,7 @@
         <dependency ref="dummy.metadata.component">
             <dependency ref="a-component"/>
             <dependency ref="dummy-component"/>
+            <dependency ref="SomeFrameworkBundle"/>
         </dependency>
         <dependency ref="SomeFrameworkBundle"/>
     </dependencies>

--- a/tests/_data/serializeResults/xml_complex_spec1.2.xml.bin
+++ b/tests/_data/serializeResults/xml_complex_spec1.2.xml.bin
@@ -106,6 +106,20 @@
                 </reference>
             </externalReferences>
         </component>
+        <component type="framework" bom-ref="SomeFrameworkBundle">
+            <name>SomeFrameworkBundle</name>
+            <version/>
+            <components>
+                <component type="library" bom-ref="SomeFrameworkBundle#SubComponentA">
+                    <name>SubComponentA</name>
+                    <version/>
+                </component>
+                <component type="library" bom-ref="SomeFrameworkBundle#SubComponentB">
+                    <name>SubComponentB</name>
+                    <version/>
+                </component>
+            </components>
+        </component>
     </components>
     <dependencies>
         <dependency ref="a-component"/>
@@ -116,5 +130,6 @@
             <dependency ref="a-component"/>
             <dependency ref="dummy-component"/>
         </dependency>
+        <dependency ref="SomeFrameworkBundle"/>
     </dependencies>
 </bom>

--- a/tests/_data/serializeResults/xml_complex_spec1.3.xml.bin
+++ b/tests/_data/serializeResults/xml_complex_spec1.3.xml.bin
@@ -131,6 +131,12 @@
             <dependency ref="dummy-component"/>
             <dependency ref="SomeFrameworkBundle"/>
         </dependency>
-        <dependency ref="SomeFrameworkBundle"/>
+        <dependency ref="SomeFrameworkBundle">
+            <dependency ref="SomeFrameworkBundle#SubComponentA"/>
+        </dependency>
+        <dependency ref="SomeFrameworkBundle#SubComponentA">
+            <dependency ref="SomeFrameworkBundle#SubComponentB"/>
+        </dependency>
+        <dependency ref="SomeFrameworkBundle#SubComponentB"/>
     </dependencies>
 </bom>

--- a/tests/_data/serializeResults/xml_complex_spec1.3.xml.bin
+++ b/tests/_data/serializeResults/xml_complex_spec1.3.xml.bin
@@ -129,6 +129,7 @@
         <dependency ref="dummy.metadata.component">
             <dependency ref="a-component"/>
             <dependency ref="dummy-component"/>
+            <dependency ref="SomeFrameworkBundle"/>
         </dependency>
         <dependency ref="SomeFrameworkBundle"/>
     </dependencies>

--- a/tests/_data/serializeResults/xml_complex_spec1.3.xml.bin
+++ b/tests/_data/serializeResults/xml_complex_spec1.3.xml.bin
@@ -106,6 +106,20 @@
                 </reference>
             </externalReferences>
         </component>
+        <component type="framework" bom-ref="SomeFrameworkBundle">
+            <name>SomeFrameworkBundle</name>
+            <version/>
+            <components>
+                <component type="library" bom-ref="SomeFrameworkBundle#SubComponentA">
+                    <name>SubComponentA</name>
+                    <version/>
+                </component>
+                <component type="library" bom-ref="SomeFrameworkBundle#SubComponentB">
+                    <name>SubComponentB</name>
+                    <version/>
+                </component>
+            </components>
+        </component>
     </components>
     <dependencies>
         <dependency ref="a-component"/>
@@ -116,5 +130,6 @@
             <dependency ref="a-component"/>
             <dependency ref="dummy-component"/>
         </dependency>
+        <dependency ref="SomeFrameworkBundle"/>
     </dependencies>
 </bom>

--- a/tests/_data/serializeResults/xml_complex_spec1.4.xml.bin
+++ b/tests/_data/serializeResults/xml_complex_spec1.4.xml.bin
@@ -133,6 +133,7 @@
         <dependency ref="dummy.metadata.component">
             <dependency ref="a-component"/>
             <dependency ref="dummy-component"/>
+            <dependency ref="SomeFrameworkBundle"/>
         </dependency>
         <dependency ref="SomeFrameworkBundle"/>
     </dependencies>

--- a/tests/_data/serializeResults/xml_complex_spec1.4.xml.bin
+++ b/tests/_data/serializeResults/xml_complex_spec1.4.xml.bin
@@ -113,6 +113,17 @@
                 </reference>
             </externalReferences>
         </component>
+        <component type="framework" bom-ref="SomeFrameworkBundle">
+            <name>SomeFrameworkBundle</name>
+            <components>
+                <component type="library" bom-ref="SomeFrameworkBundle#SubComponentA">
+                    <name>SubComponentA</name>
+                </component>
+                <component type="library" bom-ref="SomeFrameworkBundle#SubComponentB">
+                    <name>SubComponentB</name>
+                </component>
+            </components>
+        </component>
     </components>
     <dependencies>
         <dependency ref="a-component"/>
@@ -123,5 +134,6 @@
             <dependency ref="a-component"/>
             <dependency ref="dummy-component"/>
         </dependency>
+        <dependency ref="SomeFrameworkBundle"/>
     </dependencies>
 </bom>

--- a/tests/_data/serializeResults/xml_complex_spec1.4.xml.bin
+++ b/tests/_data/serializeResults/xml_complex_spec1.4.xml.bin
@@ -135,6 +135,12 @@
             <dependency ref="dummy-component"/>
             <dependency ref="SomeFrameworkBundle"/>
         </dependency>
-        <dependency ref="SomeFrameworkBundle"/>
+        <dependency ref="SomeFrameworkBundle">
+            <dependency ref="SomeFrameworkBundle#SubComponentA"/>
+        </dependency>
+        <dependency ref="SomeFrameworkBundle#SubComponentA">
+            <dependency ref="SomeFrameworkBundle#SubComponentB"/>
+        </dependency>
+        <dependency ref="SomeFrameworkBundle#SubComponentB"/>
     </dependencies>
 </bom>

--- a/tests/integration/Serialize.JsonNormalize.test.js
+++ b/tests/integration/Serialize.JsonNormalize.test.js
@@ -24,7 +24,7 @@ const { describe, beforeEach, afterEach, it } = require('mocha')
 const { createComplexStructure } = require('../_data/models')
 const { loadNormalizeResult } = require('../_data/normalize')
 /* uncomment next line to dump data */
-// const { writeNormalizeResult } = require('../_data/normalize')
+const { writeNormalizeResult } = require('../_data/normalize')
 
 const {
   Serialize: {
@@ -63,8 +63,9 @@ describe('Serialize.JsonNormalize', function () {
 
       const json = JSON.stringify(normalized, null, 2)
 
-      /* uncomment next line to dump data */
-      // writeNormalizeResult(json, 'json_sortedLists', spec.version, 'json')
+      if (process.env.CJL_TEST_UPDATE_SNAPSHOTS) {
+        writeNormalizeResult(json, 'json_sortedLists', spec.version, 'json')
+      }
 
       assert.deepStrictEqual(
         JSON.parse(json),

--- a/tests/integration/Serialize.JsonSerialize.test.js
+++ b/tests/integration/Serialize.JsonSerialize.test.js
@@ -24,7 +24,7 @@ const { describe, beforeEach, afterEach, it } = require('mocha')
 const { createComplexStructure } = require('../_data/models')
 const { loadSerializeResult } = require('../_data/serialize')
 /* uncomment next line to dump data */
-// const { writeSerializeResult } = require('../_data/serialize')
+const { writeSerializeResult } = require('../_data/serialize')
 
 const {
   Serialize: {
@@ -60,8 +60,9 @@ describe('Serialize.JsonSerialize', function () {
           space: 4
         })
 
-      /* uncomment next line to dump data */
-      // writeSerializeResult(serialized, 'json_complex', spec.version, 'json')
+      if (process.env.CJL_TEST_UPDATE_SNAPSHOTS) {
+        writeSerializeResult(serialized, 'json_complex', spec.version, 'json')
+      }
 
       assert.strictEqual(
         serialized,

--- a/tests/integration/Serialize.XmlNormalize.test.js
+++ b/tests/integration/Serialize.XmlNormalize.test.js
@@ -24,7 +24,7 @@ const { describe, beforeEach, afterEach, it } = require('mocha')
 const { createComplexStructure } = require('../_data/models')
 const { loadNormalizeResult } = require('../_data/normalize')
 /* uncomment next line to dump data */
-// const { writeNormalizeResult } = require('../_data/normalize')
+const { writeNormalizeResult } = require('../_data/normalize')
 
 const {
   Serialize: {
@@ -63,8 +63,9 @@ describe('Serialize.XmlNormalize', function () {
 
       const json = JSON.stringify(normalized, null, 2)
 
-      /* uncomment next line to dump data */
-      // writeNormalizeResult(json, 'xml_sortedLists', spec.version, 'json')
+      if (process.env.CJL_TEST_UPDATE_SNAPSHOTS) {
+        writeNormalizeResult(json, 'xml_sortedLists', spec.version, 'json')
+      }
 
       assert.deepStrictEqual(
         JSON.parse(json),

--- a/tests/integration/Serialize.XmlSerialize.test.js
+++ b/tests/integration/Serialize.XmlSerialize.test.js
@@ -24,7 +24,7 @@ const { describe, beforeEach, afterEach, it } = require('mocha')
 const { createComplexStructure } = require('../_data/models')
 const { loadSerializeResult } = require('../_data/serialize')
 /* uncomment next line to dump data */
-// const { writeSerializeResult } = require('../_data/serialize')
+const { writeSerializeResult } = require('../_data/serialize')
 
 const {
   Serialize: {
@@ -60,8 +60,9 @@ describe('Serialize.XmlSerialize', function () {
           space: 4
         })
 
-      /* uncomment next line to dump data */
-      // writeSerializeResult(serialized, 'xml_complex', spec.version, 'xml')
+      if (process.env.CJL_TEST_UPDATE_SNAPSHOTS) {
+        writeSerializeResult(serialized, 'xml_complex', spec.version, 'xml')
+      }
 
       assert.strictEqual(
         serialized,

--- a/tests/unit/Models.Component.spec.js
+++ b/tests/unit/Models.Component.spec.js
@@ -109,6 +109,7 @@ suite('Models.Component', () => {
     assert.strictEqual(component.supplier, dummySupplier)
     assert.strictEqual(component.swid, dummySWID)
     assert.strictEqual(component.version, '1.33.7')
+    assert.strictEqual(component.components.size, 1)
     assert.strictEqual(Array.from(component.components)[0], subComponent)
   })
 })

--- a/tests/unit/Models.Component.spec.js
+++ b/tests/unit/Models.Component.spec.js
@@ -26,7 +26,7 @@ const { PackageURL } = require('packageurl-js')
 
 const {
   Models: {
-    Component,
+    Component, ComponentRepository,
     BomRef, BomRefRepository,
     ExternalReferenceRepository, ExternalReference,
     HashRepository,
@@ -57,22 +57,24 @@ suite('Models.Component', () => {
     assert.strictEqual(component.supplier, undefined)
     assert.strictEqual(component.swid, undefined)
     assert.strictEqual(component.version, undefined)
+    assert.strictEqual(component.components.size, 0)
   })
 
   test('constructor with OptionalProperties', () => {
-    const dummnBomRef = new BomRef('testing')
+    const dummyBomRef = new BomRef('testing')
     const dummyExtRef = new ExternalReference('../', 'other')
     const dummyLicense = new NamedLicense('mine')
     const dummyPurl = new PackageURL('npm', 'ns', 'app', '1.33.7', {}, undefined)
     const dummySupplier = new OrganizationalEntity({ name: 'dummySupplier' })
     const dummySWID = new SWID('my-fake-swid', 'foo-bar')
+    const subComponent = new Component('library', 'MySubComponent')
 
     const component = new Component('application', 'foobar', {
       author: 'my author',
       bomRef: 'my-bomref',
       copyright: 'my copyright',
       cpe: 'cpe:2.3:a:microsoft:internet_explorer:8.0.6001:beta:*:*:*:*:*:*',
-      dependencies: new BomRefRepository([dummnBomRef]),
+      dependencies: new BomRefRepository([dummyBomRef]),
       description: 'this is a test',
       externalReferences: new ExternalReferenceRepository([dummyExtRef]),
       group: 'the-crew',
@@ -82,7 +84,8 @@ suite('Models.Component', () => {
       scope: 'optional',
       supplier: dummySupplier,
       swid: dummySWID,
-      version: '1.33.7'
+      version: '1.33.7',
+      components: new ComponentRepository([subComponent])
     })
 
     assert.strictEqual(component.type, 'application')
@@ -92,7 +95,7 @@ suite('Models.Component', () => {
     assert.strictEqual(component.copyright, 'my copyright')
     assert.strictEqual(component.cpe, 'cpe:2.3:a:microsoft:internet_explorer:8.0.6001:beta:*:*:*:*:*:*')
     assert.strictEqual(component.dependencies.size, 1)
-    assert.strictEqual(Array.from(component.dependencies)[0], dummnBomRef)
+    assert.strictEqual(Array.from(component.dependencies)[0], dummyBomRef)
     assert.strictEqual(component.description, 'this is a test')
     assert.strictEqual(component.externalReferences.size, 1)
     assert.strictEqual(Array.from(component.externalReferences)[0], dummyExtRef)
@@ -106,5 +109,6 @@ suite('Models.Component', () => {
     assert.strictEqual(component.supplier, dummySupplier)
     assert.strictEqual(component.swid, dummySWID)
     assert.strictEqual(component.version, '1.33.7')
+    assert.strictEqual(Array.from(component.components)[0], subComponent)
   })
 })


### PR DESCRIPTION
part of  #132

## added 

* Support for nested/bundled (sub-)components via `Models.Component.components` was added, including
    serialization/normalization of models and impact on dependency graphs rendering.

## implementation

* data models  for `Models.Component.components` - its another instance of `Models.ComponentRepository`
  * [x] implement
  * [x] write tests 
* implement normalizer for `Models.Component.components`
  * [x] JSON 
  * [x] XML
  * [x] have tests -- integration tests for all sec versions on normalization and serialization 
* implement dependency tree for `Models.Component.components`
  * [x] JSON 
  * [x] XML
  * [x] have tests -- integration tests for all sec versions on normalization and serialization 