### PR TITLE
spec1.4: omit empty `component.version`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+* Added
+  * CycloneDX spec version 1.4 made element `bom.component.version` optional.  
+    Therefore, serialization/normalization with this spec version will no longer render this element,
+    when its value is empty. (via [#137])
+
+[#137]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/137
+
 ## 1.0.3 - 2022-07-28
 
 * Fixed

--- a/src/serialize/json/normalize.ts
+++ b/src/serialize/json/normalize.ts
@@ -238,13 +238,13 @@ export class OrganizationalEntityNormalizer extends Base {
 
 export class ComponentNormalizer extends Base {
   normalize (data: Models.Component, options: NormalizerOptions): Normalized.Component | undefined {
-    return this._factory.spec.supportsComponentType(data.type)
+    const spec = this._factory.spec
+    return spec.supportsComponentType(data.type)
       ? {
           type: data.type,
           name: data.name,
           group: data.group || undefined,
-          // version fallback to string for spec < 1.4
-          version: data.version || '',
+          version: data.version ?? (spec.requiresComponentVersion ? '' : undefined),
           'bom-ref': data.bomRef.value || undefined,
           supplier: data.supplier === undefined
             ? undefined

--- a/src/serialize/xml/normalize.ts
+++ b/src/serialize/xml/normalize.ts
@@ -295,12 +295,21 @@ export class OrganizationalEntityNormalizer extends Base {
 
 export class ComponentNormalizer extends Base {
   normalize (data: Models.Component, options: NormalizerOptions, elementName: string): SimpleXml.Element | undefined {
-    if (!this._factory.spec.supportsComponentType(data.type)) {
+    const spec = this._factory.spec
+    if (!spec.supportsComponentType(data.type)) {
       return undefined
     }
     const supplier: SimpleXml.Element | undefined = data.supplier === undefined
       ? undefined
       : this._factory.makeForOrganizationalEntity().normalize(data.supplier, options, 'supplier')
+    const version: SimpleXml.Element | undefined = (
+      spec.requiresComponentVersion
+        ? makeTextElement
+        : makeOptionalTextElement
+    )(
+      data.version ?? '',
+      'version'
+    )
     const hashes: SimpleXml.Element | undefined = data.hashes.size > 0
       ? {
           type: 'element',
@@ -339,11 +348,7 @@ export class ComponentNormalizer extends Base {
         makeOptionalTextElement(data.publisher, 'publisher'),
         makeOptionalTextElement(data.group, 'group'),
         makeTextElement(data.name, 'name'),
-        makeTextElement(
-          // version fallback to string for spec < 1.4
-          data.version ?? '',
-          'version'
-        ),
+        version,
         makeOptionalTextElement(data.description, 'description'),
         makeOptionalTextElement(data.scope, 'scope'),
         hashes,

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -52,6 +52,8 @@ export interface Protocol {
   readonly supportsDependencyGraph: boolean
 
   readonly supportsToolReferences: boolean
+
+  readonly requiresComponentVersion: boolean
 }
 
 /**
@@ -67,6 +69,7 @@ class Spec implements Protocol {
   readonly #externalReferenceTypes: ReadonlySet<ExternalReferenceType>
   readonly #supportsDependencyGraph: boolean
   readonly #supportsToolReferences: boolean
+  readonly #requiresComponentVersion: boolean
 
   constructor (
     version: Version,
@@ -76,7 +79,8 @@ class Spec implements Protocol {
     hashValuePattern: RegExp,
     externalReferenceTypes: Iterable<ExternalReferenceType>,
     supportsDependencyGraph: boolean,
-    supportsToolReferences: boolean
+    supportsToolReferences: boolean,
+    requiresComponentVersion: boolean
   ) {
     this.#version = version
     this.#formats = new Set(formats)
@@ -86,6 +90,7 @@ class Spec implements Protocol {
     this.#externalReferenceTypes = new Set(externalReferenceTypes)
     this.#supportsDependencyGraph = supportsDependencyGraph
     this.#supportsToolReferences = supportsToolReferences
+    this.#requiresComponentVersion = requiresComponentVersion
   }
 
   get version (): Version {
@@ -119,6 +124,10 @@ class Spec implements Protocol {
 
   get supportsToolReferences (): boolean {
     return this.#supportsToolReferences
+  }
+
+  get requiresComponentVersion (): boolean {
+    return this.#requiresComponentVersion
   }
 }
 
@@ -172,7 +181,8 @@ export const Spec1dot2: Readonly<Protocol> = Object.freeze(new Spec(
     ExternalReferenceType.Other
   ],
   true,
-  false
+  false,
+  true
 ))
 
 /** Specification v1.3 */
@@ -225,7 +235,8 @@ export const Spec1dot3: Readonly<Protocol> = Object.freeze(new Spec(
     ExternalReferenceType.Other
   ],
   true,
-  false
+  false,
+  true
 ))
 
 /** Specification v1.4 */
@@ -279,7 +290,8 @@ export const Spec1dot4: Readonly<Protocol> = Object.freeze(new Spec(
     ExternalReferenceType.Other
   ],
   true,
-  true
+  true,
+  false
 ))
 
 export const SpecVersionDict = Object.freeze(Object.fromEntries([

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.4.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.4.json
@@ -46,7 +46,6 @@
     "component": {
       "type": "library",
       "name": "Root Component",
-      "version": "",
       "bom-ref": "dummy.metadata.component"
     },
     "manufacture": {
@@ -75,7 +74,6 @@
     {
       "type": "library",
       "name": "a-component",
-      "version": "",
       "bom-ref": "a-component"
     },
     {

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.4.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.4.json
@@ -151,11 +151,6 @@
               "type": "element",
               "name": "name",
               "children": "Root Component"
-            },
-            {
-              "type": "element",
-              "name": "version",
-              "children": ""
             }
           ]
         },
@@ -236,11 +231,6 @@
               "type": "element",
               "name": "name",
               "children": "a-component"
-            },
-            {
-              "type": "element",
-              "name": "version",
-              "children": ""
             }
           ]
         },

--- a/tests/_data/serializeResults/json_complex_spec1.4.json.bin
+++ b/tests/_data/serializeResults/json_complex_spec1.4.json.bin
@@ -46,7 +46,6 @@
         "component": {
             "type": "library",
             "name": "Root Component",
-            "version": "",
             "bom-ref": "dummy.metadata.component"
         },
         "manufacture": {
@@ -75,7 +74,6 @@
         {
             "type": "library",
             "name": "a-component",
-            "version": "",
             "bom-ref": "a-component"
         },
         {

--- a/tests/_data/serializeResults/xml_complex_spec1.4.xml.bin
+++ b/tests/_data/serializeResults/xml_complex_spec1.4.xml.bin
@@ -34,7 +34,6 @@
         </authors>
         <component type="library" bom-ref="dummy.metadata.component">
             <name>Root Component</name>
-            <version/>
         </component>
         <manufacture>
             <name>meta manufacture</name>
@@ -55,7 +54,6 @@
     <components>
         <component type="library" bom-ref="a-component">
             <name>a-component</name>
-            <version/>
         </component>
         <component type="library" bom-ref="dummy-component">
             <supplier>


### PR DESCRIPTION
CycloneDX spec version 1.4 made element `bom.component.version` optional.  

Therefore, serialization/normalization with this spec version will no longer render this element, when its value is empty.