### PR TITLE
add getters for construtor parameters

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+* Added
+  * Getters/properties that represent the corresponding parameters of class constructor. (via [#145])
+    * `Builders.FromPackageJson.ComponentBuilder.extRefFactory`,  
+      `Builders.FromPackageJson.ComponentBuilder.licenseFactory`
+    * `Builders.FromPackageJson.ToolBuilder.extRefFactory`
+    * `Factories.PackageUrlFactory.type`
+    * `Serialize.BomRefDiscriminator.prefix`
+    * `Serialize.JsonSerializer.normalizerFactory`
+    * `Serialize.XmlBaseSerializer.normalizerFactory`,  
+      `Serialize.XmlSerializer.normalizerFactory`
+
+[#145]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/145
+
 ## 1.1.0 - 2022-07-29
 
 * Added

--- a/src/builders/fromPackageJson.node.ts
+++ b/src/builders/fromPackageJson.node.ts
@@ -33,6 +33,10 @@ export class ToolBuilder {
     this.#extRefFactory = extRefFactory
   }
 
+  get extRefFactory (): Factories.FromPackageJson.ExternalReferenceFactory {
+    return this.#extRefFactory
+  }
+
   makeTool (data: PackageJson): Models.Tool | undefined {
     const [name, vendor] = typeof data.name === 'string'
       ? splitNameGroup(data.name)
@@ -59,6 +63,14 @@ export class ComponentBuilder {
   ) {
     this.#extRefFactory = extRefFactory
     this.#licenseFactory = licenseFactory
+  }
+
+  get extRefFactory (): Factories.FromPackageJson.ExternalReferenceFactory {
+    return this.#extRefFactory
+  }
+
+  get licenseFactory (): Factories.LicenseFactory {
+    return this.#licenseFactory
   }
 
   makeComponent (data: PackageJson, type: Enums.ComponentType = Enums.ComponentType.Library): Models.Component | undefined {

--- a/src/factories/packageUrl.ts
+++ b/src/factories/packageUrl.ts
@@ -22,15 +22,19 @@ import { PackageURL } from 'packageurl-js'
 import { ExternalReferenceType } from '../enums'
 
 export class PackageUrlFactory {
-  readonly #type: string
+  readonly #type: PackageURL['type']
 
   constructor (type: PackageURL['type']) {
     this.#type = type
   }
 
+  get type (): PackageURL['type'] {
+    return this.#type
+  }
+
   makeFromComponent (component: Component): PackageURL | undefined {
-    const qualifiers: { [key: string]: string } = {}
-    let subpath: string | undefined
+    const qualifiers: PackageURL['qualifiers'] = {}
+    let subpath: PackageURL['subpath']
 
     for (const e of component.externalReferences) {
       if (e.type === ExternalReferenceType.VCS) {

--- a/src/serialize/bomRefDiscriminator.ts
+++ b/src/serialize/bomRefDiscriminator.ts
@@ -31,6 +31,11 @@ export class BomRefDiscriminator {
     this.#prefix = prefix
   }
 
+  get prefix (): string {
+    return this.#prefix
+  }
+
+  /** Iterate over the bomRefs. */
   [Symbol.iterator] (): IterableIterator<BomRef> {
     return this.#originalValues.keys()
   }

--- a/src/serialize/json/normalize.ts
+++ b/src/serialize/json/normalize.ts
@@ -104,6 +104,10 @@ abstract class Base implements Normalizer {
     this._factory = factory
   }
 
+  get factory (): Factory {
+    return this._factory
+  }
+
   abstract normalize (data: object, options: NormalizerOptions): object | undefined
 }
 

--- a/src/serialize/jsonSerializer.ts
+++ b/src/serialize/jsonSerializer.ts
@@ -42,6 +42,10 @@ export class JsonSerializer extends BaseSerializer<Normalized.Bom> {
     this.#normalizerFactory = normalizerFactory
   }
 
+  get normalizerFactory (): NormalizerFactory {
+    return this.#normalizerFactory
+  }
+
   protected _normalize (
     bom: Bom,
     options: NormalizerOptions = {}

--- a/src/serialize/xml/normalize.ts
+++ b/src/serialize/xml/normalize.ts
@@ -104,6 +104,10 @@ abstract class Base implements Normalizer {
     this._factory = factory
   }
 
+  get factory (): Factory {
+    return this._factory
+  }
+
   /**
    * @param {*} data
    * @param {NormalizerOptions} options

--- a/src/serialize/xmlBaseSerializer.ts
+++ b/src/serialize/xmlBaseSerializer.ts
@@ -42,6 +42,10 @@ export abstract class XmlBaseSerializer extends BaseSerializer<SimpleXml.Element
     this.#normalizerFactory = normalizerFactory
   }
 
+  get normalizerFactory (): NormalizerFactory {
+    return this.#normalizerFactory
+  }
+
   protected _normalize (
     bom: Bom,
     options: NormalizerOptions = {}

--- a/tests/unit/Builders.FromPackageJson.ComponentBuilder.spec.js
+++ b/tests/unit/Builders.FromPackageJson.ComponentBuilder.spec.js
@@ -18,28 +18,25 @@ SPDX-License-Identifier: Apache-2.0
 Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
-module.exports = {
+const assert = require('assert')
+const { suite, test } = require('mocha')
 
-  /**
-   * Capitalise the first letter of a string
-   * @param {string} s
-   * @return {string}
-   */
-  capitaliseFirstLetter: s => s.charAt(0).toUpperCase() + s.slice(1),
-  /**
-   * UpperCamelCase a string
-   * @param {string} s
-   * @return {string}
-   */
-  upperCamelCase: s => s.replace(
-    /\b\w/g,
-    f => f.slice(-1).toUpperCase()
-  ).replace(/\W/g, ''),
+const {
+  Builders: { FromPackageJson: { ComponentBuilder } },
+  Factories: {
+    FromPackageJson: { ExternalReferenceFactory },
+    LicenseFactory
+  }
+} = require('../../')
 
-  /**
-   * Generate a random string of length.
-   * @param {number} length
-   * @return {string}
-   */
-  randomString: length => Math.random().toString(32).substring(2, 2 + length)
-}
+suite('Builders.FromPackageJson.ToolBuilder', () => {
+  test('construct', () => {
+    const extRefFactory = new ExternalReferenceFactory()
+    const licenseFactory = new LicenseFactory()
+
+    const actual = new ComponentBuilder(extRefFactory, licenseFactory)
+
+    assert.strictEqual(actual.extRefFactory, extRefFactory)
+    assert.strictEqual(actual.licenseFactory, licenseFactory)
+  })
+})

--- a/tests/unit/Builders.FromPackageJson.ToolBuilder.spec.js
+++ b/tests/unit/Builders.FromPackageJson.ToolBuilder.spec.js
@@ -18,28 +18,20 @@ SPDX-License-Identifier: Apache-2.0
 Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
-module.exports = {
+const assert = require('assert')
+const { suite, test } = require('mocha')
 
-  /**
-   * Capitalise the first letter of a string
-   * @param {string} s
-   * @return {string}
-   */
-  capitaliseFirstLetter: s => s.charAt(0).toUpperCase() + s.slice(1),
-  /**
-   * UpperCamelCase a string
-   * @param {string} s
-   * @return {string}
-   */
-  upperCamelCase: s => s.replace(
-    /\b\w/g,
-    f => f.slice(-1).toUpperCase()
-  ).replace(/\W/g, ''),
+const {
+  Builders: { FromPackageJson: { ToolBuilder } },
+  Factories: { FromPackageJson: { ExternalReferenceFactory } }
+} = require('../../')
 
-  /**
-   * Generate a random string of length.
-   * @param {number} length
-   * @return {string}
-   */
-  randomString: length => Math.random().toString(32).substring(2, 2 + length)
-}
+suite('Builders.FromPackageJson.ToolBuilder', () => {
+  test('construct', () => {
+    const extRefFactory = new ExternalReferenceFactory()
+
+    const actual = new ToolBuilder(extRefFactory)
+
+    assert.strictEqual(actual.extRefFactory, extRefFactory)
+  })
+})

--- a/tests/unit/Factories.PackageUrlFactory.spec.js
+++ b/tests/unit/Factories.PackageUrlFactory.spec.js
@@ -18,28 +18,21 @@ SPDX-License-Identifier: Apache-2.0
 Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
-module.exports = {
+const assert = require('assert')
+const { suite, test } = require('mocha')
 
-  /**
-   * Capitalise the first letter of a string
-   * @param {string} s
-   * @return {string}
-   */
-  capitaliseFirstLetter: s => s.charAt(0).toUpperCase() + s.slice(1),
-  /**
-   * UpperCamelCase a string
-   * @param {string} s
-   * @return {string}
-   */
-  upperCamelCase: s => s.replace(
-    /\b\w/g,
-    f => f.slice(-1).toUpperCase()
-  ).replace(/\W/g, ''),
+const {
+  Factories: { PackageUrlFactory }
+} = require('../../')
 
-  /**
-   * Generate a random string of length.
-   * @param {number} length
-   * @return {string}
-   */
-  randomString: length => Math.random().toString(32).substring(2, 2 + length)
-}
+const { randomString } = require('../_helpers/stringFunctions')
+
+suite('Builders.FromPackageJson.ToolBuilder', () => {
+  test('construct', () => {
+    const type = randomString(5)
+
+    const actual = new PackageUrlFactory(type)
+
+    assert.strictEqual(actual.type, type)
+  })
+})

--- a/tests/unit/Serialize.BomRefDiscriminator.spec.js
+++ b/tests/unit/Serialize.BomRefDiscriminator.spec.js
@@ -26,7 +26,25 @@ const {
   Serialize: { BomRefDiscriminator }
 } = require('../../')
 
+const { randomString } = require('../_helpers/stringFunctions')
+
 suite('Serialize.BomRefDiscriminator', () => {
+  test('constructor', () => {
+    const bomRef1 = new BomRef()
+    const bomRef2 = new BomRef('foo')
+    const prefix = randomString(10)
+
+    /* eslint-disable-next-line no-unused-vars */
+    const actual = new BomRefDiscriminator([bomRef1, bomRef2], prefix)
+
+    assert.strictEqual(actual.prefix, prefix)
+
+    const actualBomRefs = Array.from(actual) // convert the iterator to a list
+    assert.strictEqual(actualBomRefs.length, 2)
+    assert.strictEqual(actualBomRefs.includes(bomRef1), true)
+    assert.strictEqual(actualBomRefs.includes(bomRef2), true)
+  })
+
   test('does not alter BomRef.value unintended', () => {
     const bomRef1 = new BomRef()
     const bomRef2 = new BomRef('foo')

--- a/tests/unit/Serialize.JsonSerializer.spec.js
+++ b/tests/unit/Serialize.JsonSerializer.spec.js
@@ -18,28 +18,24 @@ SPDX-License-Identifier: Apache-2.0
 Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
-module.exports = {
+const assert = require('assert')
+const { suite, test } = require('mocha')
 
-  /**
-   * Capitalise the first letter of a string
-   * @param {string} s
-   * @return {string}
-   */
-  capitaliseFirstLetter: s => s.charAt(0).toUpperCase() + s.slice(1),
-  /**
-   * UpperCamelCase a string
-   * @param {string} s
-   * @return {string}
-   */
-  upperCamelCase: s => s.replace(
-    /\b\w/g,
-    f => f.slice(-1).toUpperCase()
-  ).replace(/\W/g, ''),
+const {
+  Serialize: {
+    JsonSerializer,
+    JSON: { Normalize: { Factory } }
+  },
+  Spec: { Spec1dot4 }
 
-  /**
-   * Generate a random string of length.
-   * @param {number} length
-   * @return {string}
-   */
-  randomString: length => Math.random().toString(32).substring(2, 2 + length)
-}
+} = require('../../')
+
+suite('Serialize.JsonSerializer', () => {
+  test('constructor', () => {
+    const normalizerFactory = new Factory(Spec1dot4)
+
+    const actual = new JsonSerializer(normalizerFactory)
+
+    assert.strictEqual(actual.normalizerFactory, normalizerFactory)
+  })
+})

--- a/tests/unit/Serialize.XmlBaseSerializer.spec.js
+++ b/tests/unit/Serialize.XmlBaseSerializer.spec.js
@@ -18,28 +18,26 @@ SPDX-License-Identifier: Apache-2.0
 Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
-module.exports = {
+const assert = require('assert')
+const { suite, test } = require('mocha')
 
-  /**
-   * Capitalise the first letter of a string
-   * @param {string} s
-   * @return {string}
-   */
-  capitaliseFirstLetter: s => s.charAt(0).toUpperCase() + s.slice(1),
-  /**
-   * UpperCamelCase a string
-   * @param {string} s
-   * @return {string}
-   */
-  upperCamelCase: s => s.replace(
-    /\b\w/g,
-    f => f.slice(-1).toUpperCase()
-  ).replace(/\W/g, ''),
+const {
+  Serialize: {
+    XmlBaseSerializer,
+    XML: { Normalize: { Factory } }
+  },
+  Spec: { Spec1dot4 }
 
-  /**
-   * Generate a random string of length.
-   * @param {number} length
-   * @return {string}
-   */
-  randomString: length => Math.random().toString(32).substring(2, 2 + length)
-}
+} = require('../../')
+
+suite('Serialize.XmlBaseSerializer', () => {
+  test('constructor', () => {
+    const normalizerFactory = new Factory(Spec1dot4)
+
+    class MySerializer extends XmlBaseSerializer {}
+
+    const actual = new MySerializer(normalizerFactory)
+
+    assert.strictEqual(actual.normalizerFactory, normalizerFactory)
+  })
+})

--- a/tests/unit/Serialize.XmlSerializer.spec.js
+++ b/tests/unit/Serialize.XmlSerializer.spec.js
@@ -18,28 +18,24 @@ SPDX-License-Identifier: Apache-2.0
 Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
-module.exports = {
+const assert = require('assert')
+const { suite, test } = require('mocha')
 
-  /**
-   * Capitalise the first letter of a string
-   * @param {string} s
-   * @return {string}
-   */
-  capitaliseFirstLetter: s => s.charAt(0).toUpperCase() + s.slice(1),
-  /**
-   * UpperCamelCase a string
-   * @param {string} s
-   * @return {string}
-   */
-  upperCamelCase: s => s.replace(
-    /\b\w/g,
-    f => f.slice(-1).toUpperCase()
-  ).replace(/\W/g, ''),
+const {
+  Serialize: {
+    XmlSerializer,
+    XML: { Normalize: { Factory } }
+  },
+  Spec: { Spec1dot4 }
 
-  /**
-   * Generate a random string of length.
-   * @param {number} length
-   * @return {string}
-   */
-  randomString: length => Math.random().toString(32).substring(2, 2 + length)
-}
+} = require('../../')
+
+suite('Serialize.XmlSerializer', () => {
+  test('constructor', () => {
+    const normalizerFactory = new Factory(Spec1dot4)
+
+    const actual = new XmlSerializer(normalizerFactory)
+
+    assert.strictEqual(actual.normalizerFactory, normalizerFactory)
+  })
+})

--- a/tests/unit/Types.cpe.spec.js
+++ b/tests/unit/Types.cpe.spec.js
@@ -23,7 +23,7 @@ const { suite, test } = require('mocha')
 
 const {
   Types: { isCPE }
-} = require('../../../')
+} = require('../../')
 
 suite('Types.cpe', () => {
   suite('isCPE()', () => {


### PR DESCRIPTION
## Added

* Getters/properties that represent the corresponding parameters of class constructor.
    * `Builders.FromPackageJson.ComponentBuilder.extRefFactory`,  
      `Builders.FromPackageJson.ComponentBuilder.licenseFactory`
    * `Builders.FromPackageJson.ToolBuilder.extRefFactory`
    * `Factories.PackageUrlFactory.type`
    * `Serialize.BomRefDiscriminator.prefix`
    * `Serialize.JsonSerializer.normalizerFactory`
    * `Serialize.XmlBaseSerializer.normalizerFactory`,  
      `Serialize.XmlSerializer.normalizerFactory`