### PR TITLE
fix normalixer of `Models.Component.properties` with CDX-1.2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+## 1.3.1 - 2022-08-04
+
+* Fixed
+  * JSON- and XML-Normalizer no longer render `Models.Component.properties`
+    with [_CycloneDX_ Specification][CycloneDX-specification]-1.2.
+    ([#152] via [#153])
+  * XML-Normalizer now has the correct order/position of rendered `Models.Component.properties`. (via [#153])
+
+[#152]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/152
+[#153]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/153
+
 ## 1.3.0 - 2022-08-03
 
 * Changed

--- a/src/serialize/json/normalize.ts
+++ b/src/serialize/json/normalize.ts
@@ -280,11 +280,11 @@ export class ComponentNormalizer extends Base {
           externalReferences: data.externalReferences.size > 0
             ? this._factory.makeForExternalReference().normalizeRepository(data.externalReferences, options)
             : undefined,
+          properties: spec.supportsProperties(data) && data.properties.size > 0
+            ? this._factory.makeForProperty().normalizeRepository(data.properties, options)
+            : undefined,
           components: data.components.size > 0
             ? this.normalizeRepository(data.components, options)
-            : undefined,
-          properties: data.properties.size > 0
-            ? this._factory.makeForProperty().normalizeRepository(data.properties, options)
             : undefined
         }
       : undefined

--- a/src/serialize/xml/normalize.ts
+++ b/src/serialize/xml/normalize.ts
@@ -344,18 +344,18 @@ export class ComponentNormalizer extends Base {
             .normalizeRepository(data.externalReferences, options, 'reference')
         }
       : undefined
+    const properties: SimpleXml.Element | undefined = spec.supportsProperties(data) && data.properties.size > 0
+      ? {
+          type: 'element',
+          name: 'properties',
+          children: this._factory.makeForProperty().normalizeRepository(data.properties, options, 'property')
+        }
+      : undefined
     const components: SimpleXml.Element | undefined = data.components.size > 0
       ? {
           type: 'element',
           name: 'components',
           children: this.normalizeRepository(data.components, options, 'component')
-        }
-      : undefined
-    const properties: SimpleXml.Element | undefined = data.properties.size > 0
-      ? {
-          type: 'element',
-          name: 'properties',
-          children: this._factory.makeForProperty().normalizeRepository(data.properties, options, 'property')
         }
       : undefined
     return {
@@ -381,8 +381,8 @@ export class ComponentNormalizer extends Base {
         makeOptionalTextElement(data.purl, 'purl'),
         swid,
         extRefs,
-        components,
-        properties
+        properties,
+        components
       ].filter(isNotUndefined)
     }
   }

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -37,28 +37,21 @@ export class UnsupportedFormatError extends Error {
 }
 
 export interface Protocol {
-  readonly version: Version
-
+  version: Version
   supportsFormat: (f: Format | any) => boolean
-
   supportsComponentType: (ct: ComponentType | any) => boolean
-
   supportsHashAlgorithm: (ha: HashAlgorithm | any) => boolean
-
   supportsHashValue: (hv: HashContent | any) => boolean
-
   supportsExternalReferenceType: (ert: ExternalReferenceType | any) => boolean
-
-  readonly supportsDependencyGraph: boolean
-
-  readonly supportsToolReferences: boolean
-
-  readonly requiresComponentVersion: boolean
+  supportsDependencyGraph: boolean
+  supportsToolReferences: boolean
+  requiresComponentVersion: boolean
+  supportsProperties: (model: any) => boolean
 }
 
 /**
- * @internal This class was never intended to be public,
- *           but it is a helper to get the exact spec-versions implemented according to {@see Protocol}.
+ * @internal This class was never intended to be public, but
+ *           it is a helper to get the exact spec-versions implemented according to {@see Protocol}.
  */
 class Spec implements Protocol {
   readonly #version: Version
@@ -70,6 +63,7 @@ class Spec implements Protocol {
   readonly #supportsDependencyGraph: boolean
   readonly #supportsToolReferences: boolean
   readonly #requiresComponentVersion: boolean
+  readonly #supportsProperties: boolean
 
   constructor (
     version: Version,
@@ -80,7 +74,8 @@ class Spec implements Protocol {
     externalReferenceTypes: Iterable<ExternalReferenceType>,
     supportsDependencyGraph: boolean,
     supportsToolReferences: boolean,
-    requiresComponentVersion: boolean
+    requiresComponentVersion: boolean,
+    supportsProperties: boolean
   ) {
     this.#version = version
     this.#formats = new Set(formats)
@@ -91,6 +86,7 @@ class Spec implements Protocol {
     this.#supportsDependencyGraph = supportsDependencyGraph
     this.#supportsToolReferences = supportsToolReferences
     this.#requiresComponentVersion = requiresComponentVersion
+    this.#supportsProperties = supportsProperties
   }
 
   get version (): Version {
@@ -128,6 +124,11 @@ class Spec implements Protocol {
 
   get requiresComponentVersion (): boolean {
     return this.#requiresComponentVersion
+  }
+
+  supportsProperties (): boolean {
+    // currently a global allow/deny -- might work based on input, in the future
+    return this.#supportsProperties
   }
 }
 
@@ -182,7 +183,8 @@ export const Spec1dot2: Readonly<Protocol> = Object.freeze(new Spec(
   ],
   true,
   false,
-  true
+  true,
+  false
 ))
 
 /** Specification v1.3 */
@@ -236,6 +238,7 @@ export const Spec1dot3: Readonly<Protocol> = Object.freeze(new Spec(
   ],
   true,
   false,
+  true,
   true
 ))
 
@@ -291,11 +294,14 @@ export const Spec1dot4: Readonly<Protocol> = Object.freeze(new Spec(
   ],
   true,
   true,
-  false
+  false,
+  true
 ))
 
-export const SpecVersionDict = Object.freeze(Object.fromEntries([
-  [Version.v1dot2, Spec1dot2],
-  [Version.v1dot3, Spec1dot3],
-  [Version.v1dot4, Spec1dot4]
-]) as { [key in Version]?: Readonly<Protocol> })
+export const SpecVersionDict: { readonly [key in Version]?: Readonly<Protocol> } = Object.freeze(
+  Object.fromEntries([
+    [Version.v1dot2, Spec1dot2],
+    [Version.v1dot3, Spec1dot3],
+    [Version.v1dot4, Spec1dot4]
+  ])
+)

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.2.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.2.json
@@ -75,21 +75,7 @@
       "type": "library",
       "name": "component-with-properties",
       "version": "",
-      "bom-ref": "ComponentWithProperties",
-      "properties": [
-        {
-          "name": "internal:testing:prop-A",
-          "value": "value A"
-        },
-        {
-          "name": "internal:testing:prop-Z",
-          "value": "value B"
-        },
-        {
-          "name": "internal:testing:prop-Z",
-          "value": "value Z"
-        }
-      ]
+      "bom-ref": "ComponentWithProperties"
     },
     {
       "type": "library",

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.2.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.2.json
@@ -236,36 +236,6 @@
               "type": "element",
               "name": "version",
               "children": ""
-            },
-            {
-              "type": "element",
-              "name": "properties",
-              "children": [
-                {
-                  "type": "element",
-                  "name": "property",
-                  "attributes": {
-                    "name": "internal:testing:prop-A"
-                  },
-                  "children": "value A"
-                },
-                {
-                  "type": "element",
-                  "name": "property",
-                  "attributes": {
-                    "name": "internal:testing:prop-Z"
-                  },
-                  "children": "value B"
-                },
-                {
-                  "type": "element",
-                  "name": "property",
-                  "attributes": {
-                    "name": "internal:testing:prop-Z"
-                  },
-                  "children": "value Z"
-                }
-              ]
             }
           ]
         },

--- a/tests/_data/serializeResults/json_complex_spec1.2.json.bin
+++ b/tests/_data/serializeResults/json_complex_spec1.2.json.bin
@@ -75,21 +75,7 @@
             "type": "library",
             "name": "component-with-properties",
             "version": "",
-            "bom-ref": "ComponentWithProperties",
-            "properties": [
-                {
-                    "name": "internal:testing:prop-A",
-                    "value": "value A"
-                },
-                {
-                    "name": "internal:testing:prop-Z",
-                    "value": "value B"
-                },
-                {
-                    "name": "internal:testing:prop-Z",
-                    "value": "value Z"
-                }
-            ]
+            "bom-ref": "ComponentWithProperties"
         },
         {
             "type": "library",

--- a/tests/_data/serializeResults/xml_complex_spec1.2.xml.bin
+++ b/tests/_data/serializeResults/xml_complex_spec1.2.xml.bin
@@ -54,11 +54,6 @@
         <component type="library" bom-ref="ComponentWithProperties">
             <name>component-with-properties</name>
             <version/>
-            <properties>
-                <property name="internal:testing:prop-A">value A</property>
-                <property name="internal:testing:prop-Z">value B</property>
-                <property name="internal:testing:prop-Z">value Z</property>
-            </properties>
         </component>
         <component type="library" bom-ref="dummy-component">
             <supplier>


### PR DESCRIPTION
* Fixed
  * JSON- and XML-Normalizer no longer render `Models.Component.properties` with [_CycloneDX_ Specification][CycloneDX-specification]-1.2. ([#152] via [#153])
  * XML-Normalizer now has the correct order/position of rendered `Models.Component.properties`. (via [#153])

[#152]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/152
[#153]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/153
[CycloneDX-specification]: https://github.com/CycloneDX/specification/tree/main/schema
