### PR TITLE
fix: `BaseSerializer` discriminate nested components

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,10 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+* Fixed
+  * All serializers render unique `bom-ref` values of nested components. ([#175] via [#176])
 * Misc
-  * Improved readability of constructor parameter types. (via [#166]) 
+  * Improved readability of constructor parameter types. (via [#166])
 
 [#166]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/166
+[#175]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/175
+[#176]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/176
 
 ## 1.3.1 - 2022-08-04
 

--- a/src/serialize/baseSerializer.ts
+++ b/src/serialize/baseSerializer.ts
@@ -17,7 +17,7 @@ SPDX-License-Identifier: Apache-2.0
 Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
-import { Bom, BomRef } from '../models'
+import { Component, Bom, BomRef } from '../models'
 import { BomRefDiscriminator } from './bomRefDiscriminator'
 import { NormalizerOptions, Serializer, SerializerOptions } from './types'
 
@@ -38,12 +38,19 @@ export abstract class BaseSerializer<NormalizedBom> implements Serializer {
 
   #getAllBomRefs (bom: Bom): Iterable<BomRef> {
     const bomRefs = new Set<BomRef>()
+    function iterComponents (cs: Iterable<Component>): void {
+      for (const { bomRef, components } of cs) {
+        bomRefs.add(bomRef)
+        iterComponents(components)
+      }
+    }
+
     if (bom.metadata.component !== undefined) {
       bomRefs.add(bom.metadata.component.bomRef)
+      iterComponents(bom.metadata.component.components)
     }
-    for (const { bomRef } of bom.components) {
-      bomRefs.add(bomRef)
-    }
+    iterComponents(bom.components)
+
     return bomRefs.values()
   }
 

--- a/tests/integration/Serialize.JsonSerialize.test.js
+++ b/tests/integration/Serialize.JsonSerialize.test.js
@@ -25,6 +25,7 @@ const { createComplexStructure } = require('../_data/models')
 const { loadSerializeResult, writeSerializeResult } = require('../_data/serialize')
 
 const {
+  Models, Enums,
   Serialize: {
     JSON: { Normalize: { Factory: JsonNormalizeFactory } },
     JsonSerializer
@@ -52,6 +53,7 @@ describe('Serialize.JsonSerialize', function () {
 
     it('serialize', function () {
       const serializer = new JsonSerializer(normalizerFactory)
+
       const serialized = serializer.serialize(
         this.bom, {
           sortLists: true,
@@ -69,4 +71,56 @@ describe('Serialize.JsonSerialize', function () {
 
     // TODO add more tests
   }))
+
+  describe('make bom-refs unique', () => {
+    it('as expected', () => {
+      const bom = new Models.Bom({
+        metadata: new Models.Metadata({
+          component: new Models.Component(Enums.ComponentType.Library, 'root', {
+            bomRef: 'testing',
+            components: new Models.ComponentRepository([
+              new Models.Component(Enums.ComponentType.Library, 'c2', {
+                bomRef: 'testing'
+              })
+            ])
+          })
+        }),
+        components: new Models.ComponentRepository([
+          new Models.Component(Enums.ComponentType.Library, 'c1', {
+            bomRef: 'testing',
+            components: new Models.ComponentRepository([
+              new Models.Component(Enums.ComponentType.Library, 'c2', {
+                bomRef: 'testing'
+              })
+            ])
+          })
+        ])
+      })
+      const knownBomRefs = [
+        bom.metadata.component.bomRef,
+        [...bom.metadata.component.components][0].bomRef,
+        [...bom.components.values()][0].bomRef,
+        [...[...bom.components][0].components][0].bomRef
+      ]
+      const normalizedBomRefs = new Set(/* will be filled on call */)
+      const bomNormalizer = {
+        normalize: (bom) => {
+          normalizedBomRefs.add(bom.metadata.component.bomRef.value)
+          normalizedBomRefs.add([...bom.metadata.component.components][0].bomRef.value)
+          normalizedBomRefs.add([...bom.components.values()][0].bomRef.value)
+          normalizedBomRefs.add([...[...bom.components][0].components][0].bomRef.value)
+          return {}
+        }
+      }
+      const normalizerFactory = { makeForBom: () => bomNormalizer, spec: Spec1dot4 }
+      const serializer = new JsonSerializer(normalizerFactory)
+
+      serializer.serialize(bom)
+
+      assert.strictEqual(normalizedBomRefs.has('testing'), true)
+      assert.strictEqual(normalizedBomRefs.size, 4, 'not every value was unique')
+      // everything back to before - all have
+      knownBomRefs.forEach(({ value }) => assert.strictEqual(value, 'testing'))
+    })
+  })
 })


### PR DESCRIPTION
fixes #175
