### PR TITLE
feat: `Factories.FromNodePackageJson.PackageUrlFactory` to omits PURL's npm defaults

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,9 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+* Added
+  * New class `Factories.FromNodePackageJson.PackageUrlFactory` that acts like `Factories.PackageUrlFactory`, but
+    omits PackageUrl's npm-specific "default derived" qualifier values for `download_url` & `vcs_url`. ([#204] via [#207])
 * Build
   * Use _TypeScript_ `v4.8.2` now, was `v4.7.4`. (via [#190])
 
+[#204]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/178
+[#207]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/207
 [#190]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/190
 
 ## 1.3.4 - 2022-08-16

--- a/src/factories/fromNodePackageJson.node.ts
+++ b/src/factories/fromNodePackageJson.node.ts
@@ -17,15 +17,23 @@ SPDX-License-Identifier: Apache-2.0
 Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
+import { PackageURL } from 'packageurl-js'
+
 import * as Models from '../models'
 import * as Enums from '../enums'
+import { PackageUrlFactory as PlainPackageUrlFactory } from './packageUrl'
 import { isNotUndefined } from '../helpers/notUndefined'
 import { PackageJson } from '../helpers/packageJson'
+import { PackageUrlQualifierNames } from '../helpers/packageUrl'
 
 /**
+ * Node-specifics.
  * @see {@link https://docs.npmjs.com/cli/v8/configuring-npm/package-json PackageJson spec}
  */
 
+/**
+ * Node-specific ExternalReferenceFactory.
+ */
 export class ExternalReferenceFactory {
   makeExternalReferences (data: PackageJson): Models.ExternalReference[] {
     const refs: Array<Models.ExternalReference | undefined> = []
@@ -84,5 +92,51 @@ export class ExternalReferenceFactory {
     return typeof url === 'string' && url.length > 0
       ? new Models.ExternalReference(url, Enums.ExternalReferenceType.IssueTracker, { comment })
       : undefined
+  }
+}
+
+const npmDefaultRegistryMatcher = /^https?:\/\/registry\.npmjs\.org/
+
+/**
+ * Node-specific PackageUrlFactory.
+ */
+export class PackageUrlFactory extends PlainPackageUrlFactory {
+  override makeFromComponent (component: Models.Component, sort: boolean = false): PackageURL | undefined {
+    const purl = super.makeFromComponent(component, sort)
+    return purl === undefined
+      ? undefined
+      : this.#finalizeQualifiers(purl)
+  }
+
+  /**
+   * Will strip unnecessary qualifiers according to {@link https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst#known-qualifiers-keyvalue-pairs PURL-SPECIFICATION}:
+   * > Do not abuse qualifiers: it can be tempting to use many qualifier keys but their usage should be limited
+   * > to the bare minimum for proper package identification to ensure that a purl stays compact and readable
+   * > in most cases.
+   *
+   * Therefore:
+   * - "vcs_url" is stripped, if a "download_url" is given.
+   * - "download_url" is stripped, if it is NPM's default registry ("registry.npmjs.org")
+   * - "checksum" is stripped, unless a "download_url" or "vcs_url" is given.
+   */
+  #finalizeQualifiers (purl: PackageURL): PackageURL {
+    const qualifiers = new Map(Object.entries(purl.qualifiers ?? {}))
+
+    const downloadUrl = qualifiers.get(PackageUrlQualifierNames.DownloadURL)
+    if (downloadUrl !== undefined) {
+      qualifiers.delete(PackageUrlQualifierNames.VcsUrl)
+      if (npmDefaultRegistryMatcher.test(downloadUrl)) {
+        qualifiers.delete(PackageUrlQualifierNames.DownloadURL)
+      }
+    }
+    if (!qualifiers.has(PackageUrlQualifierNames.DownloadURL) && !qualifiers.has(PackageUrlQualifierNames.VcsUrl)) {
+      // nothing to base a checksum on
+      qualifiers.delete(PackageUrlQualifierNames.Checksum)
+    }
+    purl.qualifiers = qualifiers.size > 0
+      ? Object.fromEntries(qualifiers.entries())
+      : undefined
+
+    return purl
   }
 }

--- a/src/factories/packageUrl.ts
+++ b/src/factories/packageUrl.ts
@@ -17,9 +17,11 @@ SPDX-License-Identifier: Apache-2.0
 Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
-import { Component } from '../models'
 import { PackageURL } from 'packageurl-js'
+
 import { ExternalReferenceType } from '../enums'
+import { Component } from '../models'
+import { PackageUrlQualifierNames } from '../helpers/packageUrl'
 
 export class PackageUrlFactory {
   readonly #type: PackageURL['type']
@@ -55,25 +57,27 @@ export class PackageUrlFactory {
       // Everything is possible: URL-encoded, not encoded, with schema, without schema
       switch (extRef.type) {
         case ExternalReferenceType.VCS:
-          [qualifiers.vcs_url, subpath] = url.split('#', 2)
+          [qualifiers[PackageUrlQualifierNames.VcsUrl], subpath] = url.split('#', 2)
           break
         case ExternalReferenceType.Distribution:
-          qualifiers.download_url = url
+          qualifiers[PackageUrlQualifierNames.DownloadURL] = url
           break
       }
     }
 
     const hashes = component.hashes
     if (hashes.size > 0) {
-      qualifiers.checksum = Array.from(
-        sort ? hashes.sorted() : hashes,
+      qualifiers[PackageUrlQualifierNames.Checksum] = Array.from(
+        sort
+          ? hashes.sorted()
+          : hashes,
         ([hashAlgo, hashCont]) => `${hashAlgo.toLowerCase()}:${hashCont.toLowerCase()}`
       ).join(',')
     }
 
     try {
       // Do not beautify the parameters here, because that is in the domain of PackageURL and its representation.
-      // No need to convert an empty `subpath` string to `undefined` and such.
+      // No need to convert an empty "subpath" string to `undefined` and such.
       return new PackageURL(
         this.#type,
         component.group,

--- a/src/helpers/packageUrl.ts
+++ b/src/helpers/packageUrl.ts
@@ -17,10 +17,13 @@ SPDX-License-Identifier: Apache-2.0
 Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
-export * from './index.common'
-
-/** @since 1.2.0 */
-export * as FromNodePackageJson from './fromNodePackageJson.node'
-
-/** @deprecated use {@link FromNodePackageJson} instead of {@link FromPackageJson} */
-export * as FromPackageJson from './fromNodePackageJson.node'
+/**
+ * Known PURL qualifier names.
+ * To be used until {@link https://github.com/package-url/packageurl-js/pull/34} gets merged
+ * and {@link https://github.com/package-url/packageurl-js/issues/35} gets sorted out.
+ */
+export const enum PackageUrlQualifierNames {
+  DownloadURL = 'download_url',
+  VcsUrl = 'vcs_url',
+  Checksum = 'checksum',
+}

--- a/tests/integration/Factories.FromNodePackageJson.PackageUrlFactory.test.js
+++ b/tests/integration/Factories.FromNodePackageJson.PackageUrlFactory.test.js
@@ -1,0 +1,302 @@
+'use strict'
+/*!
+This file is part of CycloneDX JavaScript Library.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) OWASP Foundation. All Rights Reserved.
+*/
+
+const assert = require('assert')
+const { suite, test } = require('mocha')
+
+const { PackageURL } = require('packageurl-js')
+
+const {
+  Enums,
+  Models,
+  Factories: { FromNodePackageJson: { PackageUrlFactory } }
+} = require('../../')
+
+suite('Factories.FromNodePackageJson.PackageUrlFactory', () => {
+  const salt = Math.random()
+
+  const sut = new PackageUrlFactory('testing')
+
+  suite('makeFromComponent', () => {
+    test('no-name-no-purl', () => {
+      const component = new Models.Component(
+        Enums.ComponentType.Library,
+        ''
+      )
+      const expected = undefined
+
+      const actual = sut.makeFromComponent(component)
+
+      assert.strictEqual(actual, expected)
+    })
+
+    test('name-group-version', () => {
+      const component = new Models.Component(
+        Enums.ComponentType.Library,
+        `name-${salt}`,
+        {
+          group: `@group-${salt}`,
+          version: `v1+${salt}`,
+          externalReferences: new Models.ExternalReferenceRepository([
+            new Models.ExternalReference('https://foo.bar', Enums.ExternalReferenceType.Website)
+          ])
+        }
+      )
+      const expected = new PackageURL('testing', `@group-${salt}`, `name-${salt}`, `v1+${salt}`, undefined, undefined)
+
+      const actual = sut.makeFromComponent(component)
+
+      assert.deepStrictEqual(actual, expected)
+    })
+
+    test('extRef[vcs] -> qualifiers.vcs-url without subpath', () => {
+      const component = new Models.Component(
+        Enums.ComponentType.Library,
+        `name-${salt}`,
+        {
+          externalReferences: new Models.ExternalReferenceRepository([
+            new Models.ExternalReference('git+https://foo.bar/repo.git', Enums.ExternalReferenceType.VCS)
+          ])
+        }
+      )
+      const expected = new PackageURL('testing', undefined, `name-${salt}`, undefined, { vcs_url: 'git+https://foo.bar/repo.git' }, undefined)
+
+      const actual = sut.makeFromComponent(component)
+
+      assert.deepStrictEqual(actual, expected)
+    })
+
+    test('extRef[vcs] -> qualifiers.vcs-url with subpath', () => {
+      const component = new Models.Component(
+        Enums.ComponentType.Library,
+        `name-${salt}`,
+        {
+          externalReferences: new Models.ExternalReferenceRepository([
+            new Models.ExternalReference('git+https://foo.bar/repo.git#sub/path', Enums.ExternalReferenceType.VCS)
+          ])
+        }
+      )
+      const expected = new PackageURL('testing', undefined, `name-${salt}`, undefined, { vcs_url: 'git+https://foo.bar/repo.git' }, 'sub/path')
+
+      const actual = sut.makeFromComponent(component)
+
+      assert.deepStrictEqual(actual, expected)
+    })
+
+    test('extRef[distribution] -> qualifiers.download_url', () => {
+      const component = new Models.Component(
+        Enums.ComponentType.Library,
+        `name-${salt}`,
+        {
+          externalReferences: new Models.ExternalReferenceRepository([
+            new Models.ExternalReference('https://foo.bar/download', Enums.ExternalReferenceType.Distribution)
+          ])
+        }
+      )
+      const expected = new PackageURL('testing', undefined, `name-${salt}`, undefined, { download_url: 'https://foo.bar/download' }, undefined)
+
+      const actual = sut.makeFromComponent(component)
+
+      assert.deepStrictEqual(actual, expected)
+    })
+
+    test('extRef[vcs] and extRef[distribution] -> qualifiers.download_url', () => {
+      const component = new Models.Component(
+        Enums.ComponentType.Library,
+        `name-${salt}`,
+        {
+          externalReferences: new Models.ExternalReferenceRepository([
+            new Models.ExternalReference('https://foo.bar/download', Enums.ExternalReferenceType.Distribution),
+            new Models.ExternalReference('git+https://foo.bar/repo.git', Enums.ExternalReferenceType.VCS)
+          ])
+        }
+      )
+      const expected = new PackageURL('testing', undefined, `name-${salt}`, undefined, { download_url: 'https://foo.bar/download' }, undefined)
+
+      const actual = sut.makeFromComponent(component)
+
+      assert.deepStrictEqual(actual, expected)
+    })
+
+    test('extRef[distribution] default repo -> omit', () => {
+      const downloadUrl = `https://registry.npmjs.org/name-${salt}/-/name-${salt}.tgz`
+      const component = new Models.Component(
+        Enums.ComponentType.Library,
+        `name-${salt}`,
+        {
+          externalReferences: new Models.ExternalReferenceRepository([
+            new Models.ExternalReference(downloadUrl, Enums.ExternalReferenceType.Distribution)
+          ])
+        }
+      )
+      const expected = new PackageURL('testing', undefined, `name-${salt}`, undefined, undefined, undefined)
+
+      const actual = sut.makeFromComponent(component)
+
+      assert.deepStrictEqual(actual, expected)
+    })
+
+    test('extRef[vcs] and extRef[distribution] default repo -> omit', () => {
+      const downloadUrl = `https://registry.npmjs.org/name-${salt}/-/name-${salt}.tgz`
+      const component = new Models.Component(
+        Enums.ComponentType.Library,
+        `name-${salt}`,
+        {
+          externalReferences: new Models.ExternalReferenceRepository([
+            new Models.ExternalReference(downloadUrl, Enums.ExternalReferenceType.Distribution),
+            new Models.ExternalReference('git+https://foo.bar/repo.git', Enums.ExternalReferenceType.VCS)
+          ])
+        }
+      )
+      const expected = new PackageURL('testing', undefined, `name-${salt}`, undefined, undefined, undefined)
+
+      const actual = sut.makeFromComponent(component)
+
+      assert.deepStrictEqual(actual, expected)
+    })
+
+    test('extRef empty url -> omit', () => {
+      const component = new Models.Component(
+        Enums.ComponentType.Library,
+        `name-${salt}`,
+        {
+          externalReferences: new Models.ExternalReferenceRepository([
+            new Models.ExternalReference('', Enums.ExternalReferenceType.VCS),
+            new Models.ExternalReference('', Enums.ExternalReferenceType.Distribution)
+          ])
+        }
+      )
+      const expected = new PackageURL('testing', undefined, `name-${salt}`, undefined, undefined, undefined)
+
+      const actual = sut.makeFromComponent(component)
+
+      assert.deepStrictEqual(actual, expected)
+    })
+
+    test('hashes and extRef empty url -> omit', () => {
+      const component = new Models.Component(
+        Enums.ComponentType.Library,
+        `name-${salt}`,
+        {
+          externalReferences: new Models.ExternalReferenceRepository([
+            new Models.ExternalReference('', Enums.ExternalReferenceType.VCS),
+            new Models.ExternalReference('', Enums.ExternalReferenceType.Distribution)
+          ]),
+          hashes: new Models.HashRepository([
+            [Enums.HashAlgorithm['SHA-256'], 'C3AB8FF13720E8AD9047DD39466B3C8974E592C2FA383D4A3960714CAEF0C4F2']
+          ])
+        }
+      )
+      const expected = new PackageURL('testing', undefined, `name-${salt}`, undefined, undefined, undefined)
+
+      const actual = sut.makeFromComponent(component)
+
+      assert.deepStrictEqual(actual, expected)
+    })
+
+    test('hashes -> qualifiers.checksum', () => {
+      const component = new Models.Component(
+        Enums.ComponentType.Library,
+        `name-${salt}`,
+        {
+          externalReferences: new Models.ExternalReferenceRepository([
+            new Models.ExternalReference('git+https://foo.bar/repo.git', Enums.ExternalReferenceType.VCS)
+          ]),
+          hashes: new Models.HashRepository([
+            [Enums.HashAlgorithm['SHA-256'], 'C3AB8FF13720E8AD9047DD39466B3C8974E592C2FA383D4A3960714CAEF0C4F2']
+          ])
+        }
+      )
+      const expected = new PackageURL('testing', undefined, `name-${salt}`, undefined, { checksum: 'sha-256:c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2', vcs_url: 'git+https://foo.bar/repo.git' }, undefined)
+
+      const actual = sut.makeFromComponent(component)
+
+      assert.deepStrictEqual(actual, expected)
+    })
+
+    test('sorted hashes', () => {
+      const component = new Models.Component(
+        Enums.ComponentType.Library,
+        'name',
+        {
+          externalReferences: new Models.ExternalReferenceRepository([
+            new Models.ExternalReference('git+https://foo.bar/repo.git', Enums.ExternalReferenceType.VCS)
+          ]),
+          hashes: new Models.HashRepository([
+            [Enums.HashAlgorithm['SHA-256'], 'C3AB8FF13720E8AD9047DD39466B3C8974E592C2FA383D4A3960714CAEF0C4F2'],
+            [Enums.HashAlgorithm.BLAKE3, 'aa51dcd43d5c6c5203ee16906fd6b35db298b9b2e1de3fce81811d4806b76b7d']
+          ])
+        }
+      )
+      const expectedObject = new PackageURL('testing', undefined, 'name', undefined,
+        {
+          // expect sorted hash list
+          checksum: 'blake3:aa51dcd43d5c6c5203ee16906fd6b35db298b9b2e1de3fce81811d4806b76b7d,sha-256:c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2',
+          vcs_url: 'git+https://foo.bar/repo.git'
+        }, undefined)
+      // expect objet's keys in alphabetical oder, expect sorted hash list
+      const expectedString = 'pkg:testing/name?checksum=blake3:aa51dcd43d5c6c5203ee16906fd6b35db298b9b2e1de3fce81811d4806b76b7d,sha-256:c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2&vcs_url=git+https://foo.bar/repo.git'
+
+      const actual = sut.makeFromComponent(component, true)
+
+      assert.deepStrictEqual(actual, expectedObject)
+      assert.deepStrictEqual(actual.toString(), expectedString)
+    })
+
+    test('sorted references', () => {
+      const component1 = new Models.Component(
+        Enums.ComponentType.Library,
+        'name',
+        {
+          externalReferences: new Models.ExternalReferenceRepository([
+            new Models.ExternalReference('https://foo.bar/download-1', Enums.ExternalReferenceType.Distribution),
+            new Models.ExternalReference('https://foo.bar/download-2', Enums.ExternalReferenceType.Distribution)
+          ])
+        }
+      )
+      const component2 = new Models.Component(
+        Enums.ComponentType.Library,
+        'name',
+        {
+          externalReferences: new Models.ExternalReferenceRepository([
+            // different order of extRefs
+            new Models.ExternalReference('https://foo.bar/download-2', Enums.ExternalReferenceType.Distribution),
+            new Models.ExternalReference('https://foo.bar/download-1', Enums.ExternalReferenceType.Distribution)
+          ])
+        }
+      )
+      const expectedObject = new PackageURL('testing', undefined, 'name', undefined,
+        {
+          // expect sorted hash list
+          download_url: 'https://foo.bar/download-2'
+        }, undefined)
+      // expect objet's keys in alphabetical oder, expect sorted hash list
+      const expectedString = 'pkg:testing/name?download_url=https://foo.bar/download-2'
+
+      const actual1 = sut.makeFromComponent(component1, true)
+      const actual2 = sut.makeFromComponent(component2, true)
+
+      assert.deepStrictEqual(actual1, expectedObject)
+      assert.deepStrictEqual(actual1.toString(), expectedString)
+      assert.deepStrictEqual(actual2, expectedObject)
+      assert.deepStrictEqual(actual2.toString(), expectedString)
+    })
+  })
+})


### PR DESCRIPTION
## Added
  * New class `Factories.FromNodePackageJson.PackageUrlFactory` that acts like `Factories.PackageUrlFactory`, but
    omits PackageUrl's npm-specific "default derived" qualifier values for `download_url` & `vcs_url`.

fixes #204