### PR TITLE
tsconfig: default `esModuleInterop` & `allowSyntheticDefaultImports`

### DIFF
--- a/src/resources.node.ts
+++ b/src/resources.node.ts
@@ -17,7 +17,7 @@ SPDX-License-Identifier: Apache-2.0
 Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
-import path from 'path'
+import * as path from 'path'
 
 import { Version } from './spec'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -72,7 +72,7 @@
     /* Interop Constraints */
     "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
+    "esModuleInterop": false,                             /* Disable emitting additional JavaScript to ease support for importing CommonJS modules. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
     "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -71,8 +71,8 @@
 
     /* Interop Constraints */
     "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": false,                             /* Disable emitting additional JavaScript to ease support for importing CommonJS modules. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    // "esModuleInterop": true,                          /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
     "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
 


### PR DESCRIPTION
Enables projects that use this library to also have esModuleInterop set to false (which is the more strict options), improving ease of use.