### PR TITLE
docs: add more docs to serializer

### DIFF
--- a/src/serialize/types.ts
+++ b/src/serialize/types.ts
@@ -34,5 +34,8 @@ export interface SerializerOptions {
 }
 
 export interface Serializer {
+  /**
+   * @throws {Error}
+   */
   serialize: (bom: Bom, options?: SerializerOptions & NormalizerOptions) => string
 }


### PR DESCRIPTION
goal: make the `BaseSerializer` more readable and intuitive.