### PR TITLE
docs: use TSDoc - instead of JSDoc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,9 +25,7 @@ module.exports = {
   root: true,
   extends: [
     /* see https://github.com/standard/ts-standard */
-    'standard-with-typescript',
-    /* see https://github.com/gajus/eslint-plugin-jsdoc */
-    'plugin:jsdoc/recommended'
+    'standard-with-typescript'
   ],
   parserOptions: {
     project: './tsconfig.json'
@@ -36,7 +34,9 @@ module.exports = {
     /* see https://github.com/lydell/eslint-plugin-simple-import-sort#readme */
     'simple-import-sort',
     /* see https://github.com/Stuk/eslint-plugin-header#readme */
-    'header'
+    'header',
+    /* see https://github.com/microsoft/tsdoc */
+    'eslint-plugin-tsdoc'
   ],
   env: {
     commonjs: true,
@@ -57,13 +57,40 @@ module.exports = {
       }
     },
     {
-      files: ['*.js'],
+      files: ['*.js', '*.mjs', '*.cjs'],
+      plugins: [
+        /* see https://github.com/gajus/eslint-plugin-jsdoc/ */
+        'jsdoc'
+      ],
+      extends: [
+        /* see https://github.com/gajus/eslint-plugin-jsdoc */
+        'plugin:jsdoc/recommended'
+      ],
       rules: {
         // region docs
+        'tsdoc/syntax': 0,
         /* see https://github.com/gajus/eslint-plugin-jsdoc */
+        'jsdoc/no-undefined-types': 'error',
+        'jsdoc/check-tag-names': 0,
+        'jsdoc/check-types': 'error',
+        'jsdoc/require-hyphen-before-param-description': ['error', 'always'],
+        'jsdoc/require-jsdoc': 0,
+        'jsdoc/require-param': 0,
+        'jsdoc/require-param-description': 0,
+        'jsdoc/require-param-name': 'error',
         'jsdoc/require-param-type': 'error',
+        'jsdoc/require-property': 0,
+        'jsdoc/require-property-description': 0,
+        'jsdoc/require-property-name': 'error',
         'jsdoc/require-property-type': 'error',
-        'jsdoc/require-returns-type': 'error'
+        'jsdoc/require-returns': 0,
+        'jsdoc/require-returns-check': 'error',
+        'jsdoc/require-returns-description': 0,
+        'jsdoc/require-returns-type': 'error',
+        'jsdoc/require-throws': 'error',
+        'jsdoc/require-yields': 0,
+        'jsdoc/require-yields-check': 'error',
+        'jsdoc/sort-tags': 'warn'
         // region docs
       },
       settings: {
@@ -93,38 +120,12 @@ module.exports = {
     'simple-import-sort/exports': 'error',
     // endregion sort imports/exports
     // region docs
-    /* see https://github.com/gajus/eslint-plugin-jsdoc */
-    'jsdoc/no-undefined-types': 'error',
-    'jsdoc/check-tag-names': 0,
-    'jsdoc/check-types': 'error',
-    'jsdoc/require-hyphen-before-param-description': ['error', 'always'],
-    'jsdoc/require-jsdoc': 0,
-    'jsdoc/require-param': 0,
-    'jsdoc/require-param-description': 0,
-    'jsdoc/require-param-name': 'error',
-    'jsdoc/require-param-type': 0,
-    'jsdoc/require-property': 0,
-    'jsdoc/require-property-description': 0,
-    'jsdoc/require-property-name': 'error',
-    'jsdoc/require-property-type': 0,
-    'jsdoc/require-returns': 0,
-    'jsdoc/require-returns-check': 'error',
-    'jsdoc/require-returns-description': 0,
-    'jsdoc/require-returns-type': 0,
-    'jsdoc/require-throws': 'error',
-    'jsdoc/require-yields': 0,
-    'jsdoc/require-yields-check': 'error',
-    'jsdoc/sort-tags': 'warn',
+    /* see https://github.com/microsoft/tsdoc */
+    'tsdoc/syntax': 'error',
     // endregion docs
     // region license-header
     /* see https://github.com/Stuk/eslint-plugin-header#readme */
     'header/header': ['error', '.license-header.js']
     // endregion license-header
-  },
-  settings: {
-    jsdoc: {
-      /* see https://github.com/gajus/eslint-plugin-jsdoc */
-      mode: 'typescript'
-    }
   }
 }

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+* Docs
+  * Use [TSDoc](https://tsdoc.org/) syntax in TypeScript files, instead of [JSDoc](https://jsdoc.app/) (via [##318]) 
+
 ## 1.10.0 - 2023-01-28
 
 * Added

--- a/examples/node-javascript/example.cjs
+++ b/examples/node-javascript/example.cjs
@@ -1,4 +1,3 @@
-'use strict'
 /*!
 This file is part of CycloneDX JavaScript Library.
 

--- a/examples/node-javascript/example.mjs
+++ b/examples/node-javascript/example.mjs
@@ -1,4 +1,3 @@
-'use strict'
 /*!
 This file is part of CycloneDX JavaScript Library.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-jsdoc": "^39.6.2",
         "eslint-plugin-simple-import-sort": "^10.0.0",
+        "eslint-plugin-tsdoc": "^0.2.17",
         "mocha": "10.2.0",
         "npm-run-all": "^4.1.5",
         "ts-loader": "9.4.2",
@@ -172,6 +173,37 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz",
+      "integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==",
+      "dev": true
+    },
+    "node_modules/@microsoft/tsdoc-config": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.2.tgz",
+      "integrity": "sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/tsdoc": "0.14.2",
+        "ajv": "~6.12.6",
+        "jju": "~1.4.0",
+        "resolve": "~1.19.0"
+      }
+    },
+    "node_modules/@microsoft/tsdoc-config/node_modules/resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -511,24 +543,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.48.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.2.tgz",
-      "integrity": "sha512-zEUFfonQid5KRDKoI3O+uP1GnrFd4tIHlvs+sTJXiWuypUWMuDaottkJuR612wQfOkjYbsaskSIURV9xo4f+Fw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.48.2",
-        "@typescript-eslint/visitor-keys": "5.48.2"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.49.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.49.0.tgz",
@@ -615,48 +629,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "5.48.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.2.tgz",
-      "integrity": "sha512-hE7dA77xxu7ByBc6KCzikgfRyBCTst6dZQpwaTy25iMYOnbNljDT4hjhrGEJJ0QoMjrfqrx+j1l1B9/LtKeuqA==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.48.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.2.tgz",
-      "integrity": "sha512-bibvD3z6ilnoVxUBFEgkO0k0aFvUc4Cttt0dAreEr+nrAHhWzkO83PEVVuieK3DqcgL6VAK5dkzK8XUVja5Zcg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.48.2",
-        "@typescript-eslint/visitor-keys": "5.48.2",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@typescript-eslint/utils": {
@@ -754,24 +726,6 @@
       "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "5.49.0",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.48.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.2.tgz",
-      "integrity": "sha512-z9njZLSkwmjFWUelGEwEbdf4NwKvfHxvGC0OcGN1Hp/XNDIcJ7D5DpPNPv6x6/mFvc1tQHsaWmpD/a4gOvvCJQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.48.2",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -2046,6 +2000,16 @@
         "eslint": ">=5.0.0"
       }
     },
+    "node_modules/eslint-plugin-tsdoc": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.17.tgz",
+      "integrity": "sha512-xRmVi7Zx44lOBuYqG8vzTXuL6IdGOeF9nHX17bjJ8+VE6fsxpdGem0/SBTmAwgYMKYB1WBkqRJVQ+n8GK041pA==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/tsdoc": "0.14.2",
+        "@microsoft/tsdoc-config": "0.16.2"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -3088,6 +3052,12 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true
     },
     "node_modules/js-sdsl": {
       "version": "4.3.0",
@@ -5272,6 +5242,36 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@microsoft/tsdoc": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz",
+      "integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==",
+      "dev": true
+    },
+    "@microsoft/tsdoc-config": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.2.tgz",
+      "integrity": "sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==",
+      "dev": true,
+      "requires": {
+        "@microsoft/tsdoc": "0.14.2",
+        "ajv": "~6.12.6",
+        "jju": "~1.4.0",
+        "resolve": "~1.19.0"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.1.0",
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5507,17 +5507,6 @@
         }
       }
     },
-    "@typescript-eslint/scope-manager": {
-      "version": "5.48.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.2.tgz",
-      "integrity": "sha512-zEUFfonQid5KRDKoI3O+uP1GnrFd4tIHlvs+sTJXiWuypUWMuDaottkJuR612wQfOkjYbsaskSIURV9xo4f+Fw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@typescript-eslint/types": "5.48.2",
-        "@typescript-eslint/visitor-keys": "5.48.2"
-      }
-    },
     "@typescript-eslint/type-utils": {
       "version": "5.49.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.49.0.tgz",
@@ -5565,29 +5554,6 @@
             "eslint-visitor-keys": "^3.3.0"
           }
         }
-      }
-    },
-    "@typescript-eslint/types": {
-      "version": "5.48.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.2.tgz",
-      "integrity": "sha512-hE7dA77xxu7ByBc6KCzikgfRyBCTst6dZQpwaTy25iMYOnbNljDT4hjhrGEJJ0QoMjrfqrx+j1l1B9/LtKeuqA==",
-      "dev": true,
-      "peer": true
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "5.48.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.2.tgz",
-      "integrity": "sha512-bibvD3z6ilnoVxUBFEgkO0k0aFvUc4Cttt0dAreEr+nrAHhWzkO83PEVVuieK3DqcgL6VAK5dkzK8XUVja5Zcg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@typescript-eslint/types": "5.48.2",
-        "@typescript-eslint/visitor-keys": "5.48.2",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/utils": {
@@ -5652,17 +5618,6 @@
             "eslint-visitor-keys": "^3.3.0"
           }
         }
-      }
-    },
-    "@typescript-eslint/visitor-keys": {
-      "version": "5.48.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.2.tgz",
-      "integrity": "sha512-z9njZLSkwmjFWUelGEwEbdf4NwKvfHxvGC0OcGN1Hp/XNDIcJ7D5DpPNPv6x6/mFvc1tQHsaWmpD/a4gOvvCJQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@typescript-eslint/types": "5.48.2",
-        "eslint-visitor-keys": "^3.3.0"
       }
     },
     "@webassemblyjs/ast": {
@@ -6634,6 +6589,16 @@
       "dev": true,
       "requires": {}
     },
+    "eslint-plugin-tsdoc": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.17.tgz",
+      "integrity": "sha512-xRmVi7Zx44lOBuYqG8vzTXuL6IdGOeF9nHX17bjJ8+VE6fsxpdGem0/SBTmAwgYMKYB1WBkqRJVQ+n8GK041pA==",
+      "dev": true,
+      "requires": {
+        "@microsoft/tsdoc": "0.14.2",
+        "@microsoft/tsdoc-config": "0.16.2"
+      }
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -7356,6 +7321,12 @@
           }
         }
       }
+    },
+    "jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true
     },
     "js-sdsl": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-plugin-header": "^3.1.1",
     "eslint-plugin-jsdoc": "^39.6.2",
     "eslint-plugin-simple-import-sort": "^10.0.0",
+    "eslint-plugin-tsdoc": "^0.2.17",
     "mocha": "10.2.0",
     "npm-run-all": "^4.1.5",
     "ts-loader": "9.4.2",

--- a/src/_helpers/packageJson.ts
+++ b/src/_helpers/packageJson.ts
@@ -28,8 +28,8 @@ export function splitNameGroup (data: string): [string, string?] {
 }
 
 /**
- * @see {@link https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/package.json PackageJson spec}
- * @see {@link https://docs.npmjs.com/cli/v8/configuring-npm/package-json PackageJson description}
+ * @see {@link https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/package.json|PackageJson spec}
+ * @see {@link https://docs.npmjs.com/cli/v8/configuring-npm/package-json|PackageJson description}
  */
 export interface PackageJson {
   name?: string

--- a/src/_helpers/packageJson.ts
+++ b/src/_helpers/packageJson.ts
@@ -28,8 +28,8 @@ export function splitNameGroup (data: string): [string, string?] {
 }
 
 /**
- * @see {@link https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/package.json|PackageJson spec}
- * @see {@link https://docs.npmjs.com/cli/v8/configuring-npm/package-json|PackageJson description}
+ * @see {@link https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/package.json | PackageJson spec}
+ * @see {@link https://docs.npmjs.com/cli/v8/configuring-npm/package-json | PackageJson description}
  */
 export interface PackageJson {
   name?: string

--- a/src/_helpers/packageUrl.ts
+++ b/src/_helpers/packageUrl.ts
@@ -19,11 +19,11 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 
 /**
  * Known PURL qualifier names.
- * To be used until {@link https://github.com/package-url/packageurl-js/pull/34} gets merged and released,
- * and {@link https://github.com/package-url/packageurl-js/issues/35} gets sorted out.
+ * To be used until {@link https://github.com/package-url/packageurl-js/pull/34 | PackageURL PR#34} gets merged and released,
+ * and {@link https://github.com/package-url/packageurl-js/issues/35 | PackageURL Issue#35} gets sorted out.
  *
  * For the list/spec of the well-known keys,
- * see {@link https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst#known-qualifiers-keyvalue-pairs}
+ * see {@link https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst#known-qualifiers-keyvalue-pairs | known qualifiers key/value-pairs}
  */
 export const enum PackageUrlQualifierNames {
   DownloadURL = 'download_url',

--- a/src/builders/fromNodePackageJson.node.ts
+++ b/src/builders/fromNodePackageJson.node.ts
@@ -94,19 +94,19 @@ export class ComponentBuilder {
       return undefined
     }
 
-    /** @see {@link https://docs.npmjs.com/cli/v8/configuring-npm/package-json#author} */
+    /* see https://docs.npmjs.com/cli/v8/configuring-npm/package-json#author */
     const author = typeof data.author === 'string'
       ? data.author
       : (typeof data.author?.name === 'string'
           ? data.author.name
           : undefined)
 
-    /** @see {@link https://docs.npmjs.com/cli/v8/configuring-npm/package-json#description-1} */
+    /* see https://docs.npmjs.com/cli/v8/configuring-npm/package-json#description-1 */
     const description = typeof data.description === 'string'
       ? data.description
       : undefined
 
-    /** @see {@link https://docs.npmjs.com/cli/v8/configuring-npm/package-json#version} */
+    /* see https://docs.npmjs.com/cli/v8/configuring-npm/package-json#version */
     const version = typeof data.version === 'string'
       ? data.version
       : undefined
@@ -115,11 +115,11 @@ export class ComponentBuilder {
 
     const licenses = new Models.LicenseRepository()
     if (typeof data.license === 'string') {
-      /** @see {@link https://docs.npmjs.com/cli/v8/configuring-npm/package-json#license} */
+      /* see https://docs.npmjs.com/cli/v8/configuring-npm/package-json#license */
       licenses.add(this.#licenseFactory.makeFromString(data.license))
     }
     if (Array.isArray(data.licenses)) {
-      /** @see {@link https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/package.json} */
+      /* see https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/package.json */
       for (const licenseData of data.licenses) {
         if (typeof licenseData?.type === 'string') {
           const license = this.#licenseFactory.makeDisjunctive(licenseData.type)

--- a/src/factories/fromNodePackageJson.node.ts
+++ b/src/factories/fromNodePackageJson.node.ts
@@ -110,10 +110,12 @@ export class PackageUrlFactory extends PlainPackageUrlFactory {
   }
 
   /**
-   * Will strip unnecessary qualifiers according to [PURL-SPECIFICATION](https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst#known-qualifiers-keyvalue-pairs):
-   * > Do not abuse qualifiers: it can be tempting to use many qualifier keys but their usage should be limited
-   * > to the bare minimum for proper package identification to ensure that a purl stays compact and readable
-   * > in most cases.
+   * Will strip unnecessary qualifiers according to [PURL-SPECIFICATION](https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst#known-qualifiers-keyvalue-pairs).
+   * <blockquote cite="https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst#known-qualifiers-keyvalue-pairs">
+   *   Do not abuse qualifiers: it can be tempting to use many qualifier keys but their usage should be limited
+   *   to the bare minimum for proper package identification to ensure that a purl stays compact and readable
+   *   in most cases.
+   * </blockquote>
    *
    * Therefore:
    * - "vcs_url" is stripped, if a "download_url" is given.

--- a/src/factories/fromNodePackageJson.node.ts
+++ b/src/factories/fromNodePackageJson.node.ts
@@ -47,7 +47,7 @@ export class ExternalReferenceFactory {
   }
 
   makeVcs (data: PackageJson): Models.ExternalReference | undefined {
-    /** @see [the spec](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#repositoryc) */
+    /* see https://docs.npmjs.com/cli/v8/configuring-npm/package-json#repositoryc */
     const repository = data.repository
     let url
     let comment: string | undefined
@@ -69,7 +69,7 @@ export class ExternalReferenceFactory {
   }
 
   makeHomepage (data: PackageJson): Models.ExternalReference | undefined {
-    /** @see [the spec](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#homepage) */
+    /* see https://docs.npmjs.com/cli/v8/configuring-npm/package-json#homepage */
     const url = data.homepage
     return typeof url === 'string' && url.length > 0
       ? new Models.ExternalReference(
@@ -79,7 +79,7 @@ export class ExternalReferenceFactory {
   }
 
   makeIssueTracker (data: PackageJson): Models.ExternalReference | undefined {
-    /** @see [the spec](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#bugs) */
+    /* see https://docs.npmjs.com/cli/v8/configuring-npm/package-json#bugs */
     const bugs = data.bugs
     let url
     let comment: string | undefined

--- a/src/factories/license.ts
+++ b/src/factories/license.ts
@@ -31,7 +31,7 @@ export class LicenseFactory {
   }
 
   /**
-   * @throws {RangeError} if expression is not eligible
+   * @throws {@link RangeError} if expression is not eligible
    */
   makeExpression (value: string): LicenseExpression {
     return new LicenseExpression(value)
@@ -46,7 +46,7 @@ export class LicenseFactory {
   }
 
   /**
-   * @throws {RangeError} if value is not supported SPDX id
+   * @throws {@link RangeError} if value is not supported SPDX id
    */
   makeDisjunctiveWithId (value: string | any): SpdxLicense {
     const spdxId = fixupSpdxId(String(value))

--- a/src/models/bom.ts
+++ b/src/models/bom.ts
@@ -46,8 +46,8 @@ export class Bom {
   // The dependency graph can be normalized on render-time, no need to store it in the bom model.
 
   /**
-   * @throws {TypeError} if `op.version` is neither {@link PositiveInteger} nor `undefined`
-   * @throws {TypeError} if `op.serialNumber` is neither {@link UrnUuid} nor `undefined`
+   * @throws {@link TypeError} if `op.version` is neither {@link PositiveInteger} nor `undefined`
+   * @throws {@link TypeError} if `op.serialNumber` is neither {@link UrnUuid} nor `undefined`
    */
   constructor (op: OptionalBomProperties = {}) {
     this.metadata = op.metadata ?? new Metadata()
@@ -61,7 +61,7 @@ export class Bom {
   }
 
   /**
-   * @throws {TypeError} if value is not {@link PositiveInteger}
+   * @throws {@link TypeError} if value is not {@link PositiveInteger}
    */
   set version (value: PositiveInteger) {
     if (!isPositiveInteger(value)) {
@@ -75,7 +75,7 @@ export class Bom {
   }
 
   /**
-   * @throws {TypeError} if value is neither {@link UrnUuid} nor `undefined`
+   * @throws {@link TypeError} if value is neither {@link UrnUuid} nor `undefined`
    */
   set serialNumber (value: UrnUuid | undefined) {
     if (value !== undefined && !isUrnUuid(value)) {

--- a/src/models/bom.ts
+++ b/src/models/bom.ts
@@ -33,10 +33,10 @@ export class Bom {
   metadata: Metadata
   components: ComponentRepository
 
-  /** @see version */
+  /** @see {@link version} */
   #version: PositiveInteger = 1
 
-  /** @see serialNumber */
+  /** @see {@link serialNumber} */
   #serialNumber?: UrnUuid
 
   // Property `bomFormat` is not part of model, it is runtime information.

--- a/src/models/component.ts
+++ b/src/models/component.ts
@@ -81,7 +81,7 @@ export class Component implements Comparable<Component> {
   #cpe?: CPE
 
   /**
-   * @throws {TypeError} if `op.cpe` is neither {@link CPE} nor `undefined`
+   * @throws {@link TypeError} if `op.cpe` is neither {@link CPE} nor `undefined`
    */
   constructor (type: Component['type'], name: Component['name'], op: OptionalComponentProperties = {}) {
     this.#bomRef = new BomRef(op.bomRef)
@@ -115,7 +115,7 @@ export class Component implements Comparable<Component> {
   }
 
   /**
-   * @throws {TypeError} if value is neither {@link CPE} nor `undefined`
+   * @throws {@link TypeError} if value is neither {@link CPE} nor `undefined`
    */
   set cpe (value: CPE | undefined) {
     if (value !== undefined && !isCPE(value)) {

--- a/src/models/component.ts
+++ b/src/models/component.ts
@@ -74,10 +74,10 @@ export class Component implements Comparable<Component> {
   components: ComponentRepository
   properties: PropertyRepository
 
-  /** @see bomRef */
+  /** @see {@link bomRef} */
   readonly #bomRef: BomRef
 
-  /** @see cpe */
+  /** @see {@link cpe} */
   #cpe?: CPE
 
   /**

--- a/src/models/license.ts
+++ b/src/models/license.ts
@@ -32,7 +32,7 @@ export class LicenseExpression {
       expression[expression.length - 1] === ')'
   }
 
-  /** @see expression */
+  /** @see {@link expression} */
   #expression!: string
 
   /**
@@ -91,7 +91,7 @@ export class SpdxLicense {
   text?: Attachment
   url?: URL | string
 
-  /** @see id */
+  /** @see {@link id} */
   #id!: SpdxId
 
   /**

--- a/src/models/license.ts
+++ b/src/models/license.ts
@@ -36,7 +36,7 @@ export class LicenseExpression {
   #expression!: string
 
   /**
-   * @throws {RangeError} if `expression` is not {@link LicenseExpression.isEligibleExpression eligible}
+   * @throws {@link RangeError} if `expression` is not {@link LicenseExpression.isEligibleExpression|eligible}
    */
   constructor (expression: LicenseExpression['expression']) {
     this.expression = expression
@@ -47,7 +47,7 @@ export class LicenseExpression {
   }
 
   /**
-   * @throws {RangeError} if value is not {@link LicenseExpression.isEligibleExpression eligible}
+   * @throws {@link RangeError} if value is not {@link LicenseExpression.isEligibleExpression|eligible}
    */
   set expression (value: string) {
     if (!LicenseExpression.isEligibleExpression(value)) {
@@ -95,7 +95,7 @@ export class SpdxLicense {
   #id!: SpdxId
 
   /**
-   * @throws {RangeError} if `id` is not {@link isSupportedSpdxId supported}
+   * @throws {@link RangeError} if `id` is not {@link isSupportedSpdxId|supported}
    */
   constructor (id: SpdxLicense['id'], op: OptionalSpdxLicenseProperties = {}) {
     this.id = id
@@ -108,7 +108,7 @@ export class SpdxLicense {
   }
 
   /**
-   * @throws {RangeError} if value is not {@link isSupportedSpdxId supported}
+   * @throws {@link RangeError} if value is not {@link isSupportedSpdxId|supported}
    */
   set id (value: SpdxId) {
     if (!isSupportedSpdxId(value)) {

--- a/src/models/license.ts
+++ b/src/models/license.ts
@@ -36,7 +36,7 @@ export class LicenseExpression {
   #expression!: string
 
   /**
-   * @throws {@link RangeError} if `expression` is not {@link LicenseExpression.isEligibleExpression|eligible}
+   * @throws {@link RangeError} if `expression` is not {@link LicenseExpression.isEligibleExpression | eligible}
    */
   constructor (expression: LicenseExpression['expression']) {
     this.expression = expression
@@ -47,7 +47,7 @@ export class LicenseExpression {
   }
 
   /**
-   * @throws {@link RangeError} if value is not {@link LicenseExpression.isEligibleExpression|eligible}
+   * @throws {@link RangeError} if value is not {@link LicenseExpression.isEligibleExpression | eligible}
    */
   set expression (value: string) {
     if (!LicenseExpression.isEligibleExpression(value)) {
@@ -95,7 +95,7 @@ export class SpdxLicense {
   #id!: SpdxId
 
   /**
-   * @throws {@link RangeError} if `id` is not {@link isSupportedSpdxId|supported}
+   * @throws {@link RangeError} if `id` is not {@link isSupportedSpdxId | supported}
    */
   constructor (id: SpdxLicense['id'], op: OptionalSpdxLicenseProperties = {}) {
     this.id = id
@@ -108,7 +108,7 @@ export class SpdxLicense {
   }
 
   /**
-   * @throws {@link RangeError} if value is not {@link isSupportedSpdxId|supported}
+   * @throws {@link RangeError} if value is not {@link isSupportedSpdxId | supported}
    */
   set id (value: SpdxId) {
     if (!isSupportedSpdxId(value)) {

--- a/src/models/swid.ts
+++ b/src/models/swid.ts
@@ -44,7 +44,7 @@ export class SWID {
   #tagVersion?: NonNegativeInteger
 
   /**
-   * @throws {TypeError} if `op.tagVersion` is neither {@link NonNegativeInteger} nor `undefined`
+   * @throws {@link TypeError} if `op.tagVersion` is neither {@link NonNegativeInteger} nor `undefined`
    */
   constructor (tagId: SWID['tagId'], name: SWID['name'], op: OptionalSWIDProperties = {}) {
     this.tagId = tagId
@@ -61,7 +61,7 @@ export class SWID {
   }
 
   /**
-   * @throws {TypeError} if value is neither {@link NonNegativeInteger} nor `undefined`
+   * @throws {@link TypeError} if value is neither {@link NonNegativeInteger} nor `undefined`
    */
   set tagVersion (value: NonNegativeInteger | undefined) {
     if (value !== undefined && !isNonNegativeInteger(value)) {

--- a/src/models/swid.ts
+++ b/src/models/swid.ts
@@ -40,7 +40,7 @@ export class SWID {
   text?: Attachment
   url?: URL | string
 
-  /** @see tagVersion */
+  /** @see {@link tagVersion} */
   #tagVersion?: NonNegativeInteger
 
   /**

--- a/src/models/swid.ts
+++ b/src/models/swid.ts
@@ -30,7 +30,7 @@ export interface OptionalSWIDProperties {
 }
 
 /**
- * @see {@link https://csrc.nist.gov/projects/Software-Identification-SWID}
+ * @see {@link https://csrc.nist.gov/projects/Software-Identification-SWID | SWID spec}
  */
 export class SWID {
   tagId: string

--- a/src/serialize/baseSerializer.ts
+++ b/src/serialize/baseSerializer.ts
@@ -41,7 +41,7 @@ export abstract class BaseSerializer<NormalizedBom> implements Serializer {
   }
 
   /**
-   * @throws {Error}
+   * @throws {@link Error}
    */
   #normalize (bom: Bom, options?: NormalizerOptions): NormalizedBom {
     const bomRefDiscriminator = new BomRefDiscriminator(this.#getAllBomRefs(bom))
@@ -57,7 +57,7 @@ export abstract class BaseSerializer<NormalizedBom> implements Serializer {
 
   /**
    * @readonly
-   * @throws {Error}
+   * @throws {@link Error}
    */
   public serialize (bom: Bom, options?: SerializerOptions & NormalizerOptions): string {
     return this._serialize(
@@ -67,12 +67,12 @@ export abstract class BaseSerializer<NormalizedBom> implements Serializer {
   }
 
   /**
-   * @throws {Error}
+   * @throws {@link Error}
    */
   protected abstract _normalize (bom: Bom, options?: NormalizerOptions): NormalizedBom
 
   /**
-   * @throws {Error}
+   * @throws {@link Error}
    */
   protected abstract _serialize (normalizedBom: NormalizedBom, options?: SerializerOptions): string
 }

--- a/src/serialize/json/types.ts
+++ b/src/serialize/json/types.ts
@@ -26,7 +26,7 @@ import type { CPE, Integer, UrnUuid } from '../../types'
 export namespace JsonSchema {
 
   /**
-   * @see isIriReference
+   * @see {@link isIriReference}
    */
   export type IriReference = string
   /**
@@ -41,7 +41,7 @@ export namespace JsonSchema {
   }
 
   /**
-   * @see isIdnEmail
+   * @see {@link isIdnEmail}
    */
   export type IdnEmail = string
   /**

--- a/src/serialize/json/types.ts
+++ b/src/serialize/json/types.ts
@@ -33,7 +33,7 @@ export namespace JsonSchema {
    * Test whether format is JSON::iri-reference - best-effort.
    *
    * @TODO add more validation according to spec
-   * @see {@link https://datatracker.ietf.org/doc/html/rfc3987}
+   * @see {@link https://datatracker.ietf.org/doc/html/rfc3987 | RFC 3987}
    */
   export function isIriReference (value: IriReference | any): value is IriReference {
     return typeof value === 'string' &&
@@ -48,7 +48,7 @@ export namespace JsonSchema {
    * Test whether format is JSON::idn-email - best-effort.
    *
    * @TODO add more validation according to spec
-   * @see {@link https://datatracker.ietf.org/doc/html/rfc6531}
+   * @see {@link https://datatracker.ietf.org/doc/html/rfc6531 | RFC 6531}
    */
   export function isIdnEmail (value: IdnEmail | any): value is IdnEmail {
     return typeof value === 'string' &&
@@ -145,7 +145,7 @@ export namespace Normalized {
 
   export interface SpdxLicense {
     license: {
-      /** @see {@link http://cyclonedx.org/schema/spdx} */
+      /* see http://cyclonedx.org/schema/spdx */
       id: SpdxId
       text?: Attachment
       url?: string

--- a/src/serialize/jsonSerializer.ts
+++ b/src/serialize/jsonSerializer.ts
@@ -31,7 +31,7 @@ export class JsonSerializer extends BaseSerializer<Normalized.Bom> {
   readonly #normalizerFactory: NormalizerFactory
 
   /**
-   * @throws {UnsupportedFormatError} if `normalizerFactory.spec` does not support {@link Format.JSON}.
+   * @throws {@link UnsupportedFormatError} if `normalizerFactory.spec` does not support {@link Format.JSON}.
    */
   constructor (normalizerFactory: JsonSerializer['normalizerFactory']) {
     if (!normalizerFactory.spec.supportsFormat(Format.JSON)) {

--- a/src/serialize/types.ts
+++ b/src/serialize/types.ts
@@ -35,7 +35,7 @@ export interface SerializerOptions {
 
 export interface Serializer {
   /**
-   * @throws {Error}
+   * @throws {@link Error}
    */
   serialize: (bom: Bom, options?: SerializerOptions & NormalizerOptions) => string
 }

--- a/src/serialize/xml/normalize.ts
+++ b/src/serialize/xml/normalize.ts
@@ -121,7 +121,7 @@ abstract class Base<TModel, TNormalized=SimpleXml.Element> implements Normalizer
   }
 
   /**
-   * @param {string} [elementName] - element name. XML defines structures; the element's name is defined on usage of a structure.
+   * @param elementName - element name. XML defines structures; the element's name is defined on usage of a structure.
    */
   abstract normalize (data: TModel, options: NormalizerOptions, elementName?: string): TNormalized | undefined
 }

--- a/src/serialize/xml/types.ts
+++ b/src/serialize/xml/types.ts
@@ -31,9 +31,9 @@ export namespace XmlSchema {
    * Test whether format is XML::anyURI - best-effort.
    *
    * @TODO add more validation according to spec
-   * @see {@link http://www.w3.org/TR/xmlschema-2/#anyURI}
-   * @see {@link https://www.w3.org/2011/04/XMLSchema/TypeLibrary-URI-RFC3986.xsd}
-   * @see {@link https://www.w3.org/2011/04/XMLSchema/TypeLibrary-IRI-RFC3987.xsd}
+   * @see {@link http://www.w3.org/TR/xmlschema-2/#anyURI | anyURI spec}
+   * @see {@link https://www.w3.org/2011/04/XMLSchema/TypeLibrary-URI-RFC3986.xsd | RFC 3986}
+   * @see {@link https://www.w3.org/2011/04/XMLSchema/TypeLibrary-IRI-RFC3987.xsd | RFC 3987}
    */
   export function isAnyURI (value: AnyURI | any): value is AnyURI {
     if (typeof value !== 'string') {

--- a/src/serialize/xml/types.ts
+++ b/src/serialize/xml/types.ts
@@ -23,7 +23,7 @@ export namespace XmlSchema {
   const _AnyUriSchemePattern = /^[a-z][a-z0-9+\-.]*$/i
 
   /**
-   * @see isAnyURI
+   * @see {@link isAnyURI}
    */
   export type AnyURI = string
 

--- a/src/serialize/xmlBaseSerializer.ts
+++ b/src/serialize/xmlBaseSerializer.ts
@@ -31,7 +31,7 @@ export abstract class XmlBaseSerializer extends BaseSerializer<SimpleXml.Element
   readonly #normalizerFactory: NormalizerFactory
 
   /**
-   * @throws {UnsupportedFormatError} if `normalizerFactory.spec` does not support {@link Format.XML}.
+   * @throws {@link UnsupportedFormatError} if `normalizerFactory.spec` does not support {@link Format.XML}.
    */
   constructor (normalizerFactory: XmlBaseSerializer['normalizerFactory']) {
     if (!normalizerFactory.spec.supportsFormat(Format.XML)) {

--- a/src/spdx.ts
+++ b/src/spdx.ts
@@ -25,7 +25,7 @@ import {enum as _spdxSpecEnum} from '../res/spdx.SNAPSHOT.schema.json'
 /**
  * One of the known SPDX licence identifiers.
  *
- * @see {@link http://cyclonedx.org/schema/spdx|SPDX schema}
+ * @see {@link http://cyclonedx.org/schema/spdx | SPDX schema}
  * @see {@link isSupportedSpdxId}
  * @see {@link fixupSpdxId}
  */

--- a/src/spdx.ts
+++ b/src/spdx.ts
@@ -25,7 +25,7 @@ import {enum as _spdxSpecEnum} from '../res/spdx.SNAPSHOT.schema.json'
 /**
  * One of the known SPDX licence identifiers.
  *
- * @see {@link http://cyclonedx.org/schema/spdx SPDX schema}
+ * @see {@link http://cyclonedx.org/schema/spdx|SPDX schema}
  * @see {@link isSupportedSpdxId}
  * @see {@link fixupSpdxId}
  */

--- a/src/types/cpe.ts
+++ b/src/types/cpe.ts
@@ -21,7 +21,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
  * Define the format for acceptable CPE URIs. Supports CPE 2.2 and CPE 2.3 formats.
  * Refer to {@link https://nvd.nist.gov/products/cpe} for official specification.
  *
- * @see isCPE
+ * @see {@link isCPE}
  */
 export type CPE = string
 

--- a/src/types/integer.ts
+++ b/src/types/integer.ts
@@ -20,7 +20,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 /**
  * Integer
  *
- * @see isInteger
+ * @see {@link isInteger}
  */
 export type Integer = number | NonNegativeInteger
 
@@ -31,7 +31,7 @@ export function isInteger (value: any): value is Integer {
 /**
  * Integer greater than 0
  *
- * @see isNonNegativeInteger
+ * @see {@link isNonNegativeInteger}
  */
 export type NonNegativeInteger = number | PositiveInteger
 
@@ -43,7 +43,7 @@ export function isNonNegativeInteger (value: any): value is NonNegativeInteger {
 /**
  * Integer greater 0
  *
- * @see isPositiveInteger
+ * @see {@link isPositiveInteger}
  */
 export type PositiveInteger = number
 

--- a/src/types/mimeType.ts
+++ b/src/types/mimeType.ts
@@ -18,7 +18,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
 /**
- * @see isMimeType
+ * @see {@link isMimeType}
  */
 export type MimeType = string
 

--- a/src/types/urn.ts
+++ b/src/types/urn.ts
@@ -18,9 +18,9 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
 /**
- * Defines a string representation of a UUID conforming to RFC 4122.
+ * Defines a string representation of a UUID conforming to
+ * {@link https://datatracker.ietf.org/doc/html/rfc4122 | RFC 4122}.
  *
- * @see {@link https://datatracker.ietf.org/doc/html/rfc4122}
  * @see isUrnUuid
  */
 export type UrnUuid = string

--- a/src/types/urn.ts
+++ b/src/types/urn.ts
@@ -21,7 +21,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
  * Defines a string representation of a UUID conforming to
  * {@link https://datatracker.ietf.org/doc/html/rfc4122 | RFC 4122}.
  *
- * @see isUrnUuid
+ * @see {@link isUrnUuid}
  */
 export type UrnUuid = string
 

--- a/tsdoc.json
+++ b/tsdoc.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "tagDefinitions": [
+    {
+      "tagName": "@since",
+      "syntaxKind": "block",
+      "allowMultiple": false
+    },
+    {
+      "tagName": "@TODO",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    }
+  ]
+}

--- a/tsdoc.json
+++ b/tsdoc.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["typedoc/tsdoc.json"],
   "tagDefinitions": [
     {
       "tagName": "@since",


### PR DESCRIPTION
* ship valid tsdoc - https://tsdoc.org 
* improved docs rendering for links and refs

on the long run i would prefer TSDoc is ts-files, and JsDoc in js files .... 

supports #57

OUTDATED: 
> unfortunatelty the IDEs I tested do not know TSDoc. they know JsDOC instead ... therefore: #319
> Hope this changes in the future. see https://youtrack.jetbrains.com/issue/WEB-36309/Integrate-TSDOC-to-webstorm


----

- [x] have validator(eslint-plugin) for TSDOc
- [x] have all JSDoc in tyescript files converted to TSDOc