### PR TITLE
feat: export optional properties of modules

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 * Added
   * Ship [TypeDoc](https://typedoc.org) configuration, so that users can build the documentation on demand ([#57] via [#436])
+  * Typing: Interfaces of models' optional properties are now public API ([#439] via [#440])
 * Fixed
   * XML serializer now properly throws `UnsupportedFormatError` if it is unsupported by the supplied Spec (via [#438])
 * Misc
@@ -24,6 +25,8 @@ All notable changes to this project will be documented in this file.
 [#433]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/433
 [#436]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/436
 [#438]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/438
+[#439]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/439
+[#440]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/440
 
 ## 1.9.2 - 2022-12-16
 

--- a/src/models/attachment.ts
+++ b/src/models/attachment.ts
@@ -19,7 +19,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 
 import { AttachmentEncoding } from '../enums'
 
-export interface AttachmentOptionalProperties {
+export interface OptionalAttachmentProperties {
   contentType?: Attachment['contentType']
   encoding?: Attachment['encoding']
 }
@@ -29,7 +29,7 @@ export class Attachment {
   content: string
   encoding?: AttachmentEncoding
 
-  constructor (content: Attachment['content'], op: AttachmentOptionalProperties = {}) {
+  constructor (content: Attachment['content'], op: OptionalAttachmentProperties = {}) {
     this.contentType = op.contentType
     this.content = content
     this.encoding = op.encoding

--- a/src/models/attachment.ts
+++ b/src/models/attachment.ts
@@ -19,7 +19,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 
 import { AttachmentEncoding } from '../enums'
 
-interface OptionalProperties {
+export interface AttachmentOptionalProperties {
   contentType?: Attachment['contentType']
   encoding?: Attachment['encoding']
 }
@@ -29,7 +29,7 @@ export class Attachment {
   content: string
   encoding?: AttachmentEncoding
 
-  constructor (content: Attachment['content'], op: OptionalProperties = {}) {
+  constructor (content: Attachment['content'], op: AttachmentOptionalProperties = {}) {
     this.contentType = op.contentType
     this.content = content
     this.encoding = op.encoding

--- a/src/models/bom.ts
+++ b/src/models/bom.ts
@@ -21,7 +21,7 @@ import { isPositiveInteger, isUrnUuid, PositiveInteger, UrnUuid } from '../types
 import { ComponentRepository } from './component'
 import { Metadata } from './metadata'
 
-interface OptionalProperties {
+export interface BomOptionalProperties {
   metadata?: Bom['metadata']
   components?: Bom['components']
   version?: Bom['version']
@@ -48,7 +48,7 @@ export class Bom {
    * @throws {TypeError} if {@link op.version} is neither {@link PositiveInteger} nor {@link undefined}
    * @throws {TypeError} if {@link op.serialNumber} is neither {@link UrnUuid} nor {@link undefined}
    */
-  constructor (op: OptionalProperties = {}) {
+  constructor (op: BomOptionalProperties = {}) {
     this.metadata = op.metadata ?? new Metadata()
     this.components = op.components ?? new ComponentRepository()
     this.version = op.version ?? this.version

--- a/src/models/bom.ts
+++ b/src/models/bom.ts
@@ -21,7 +21,7 @@ import { isPositiveInteger, isUrnUuid, PositiveInteger, UrnUuid } from '../types
 import { ComponentRepository } from './component'
 import { Metadata } from './metadata'
 
-export interface BomOptionalProperties {
+export interface OptionalBomProperties {
   metadata?: Bom['metadata']
   components?: Bom['components']
   version?: Bom['version']
@@ -48,7 +48,7 @@ export class Bom {
    * @throws {TypeError} if {@link op.version} is neither {@link PositiveInteger} nor {@link undefined}
    * @throws {TypeError} if {@link op.serialNumber} is neither {@link UrnUuid} nor {@link undefined}
    */
-  constructor (op: BomOptionalProperties = {}) {
+  constructor (op: OptionalBomProperties = {}) {
     this.metadata = op.metadata ?? new Metadata()
     this.components = op.components ?? new ComponentRepository()
     this.version = op.version ?? this.version

--- a/src/models/component.ts
+++ b/src/models/component.ts
@@ -31,7 +31,7 @@ import { OrganizationalEntity } from './organizationalEntity'
 import { PropertyRepository } from './property'
 import { SWID } from './swid'
 
-interface OptionalComponentProperties {
+export interface OptionalComponentProperties {
   bomRef?: BomRef['value']
   author?: Component['author']
   copyright?: Component['copyright']

--- a/src/models/component.ts
+++ b/src/models/component.ts
@@ -31,7 +31,7 @@ import { OrganizationalEntity } from './organizationalEntity'
 import { PropertyRepository } from './property'
 import { SWID } from './swid'
 
-interface OptionalProperties {
+interface ComponentOptionalProperties {
   bomRef?: BomRef['value']
   author?: Component['author']
   copyright?: Component['copyright']
@@ -81,7 +81,7 @@ export class Component implements Comparable<Component> {
   /**
    * @throws {TypeError} if {@link op.cpe} is neither {@link CPE} nor {@link undefined}
    */
-  constructor (type: Component['type'], name: Component['name'], op: OptionalProperties = {}) {
+  constructor (type: Component['type'], name: Component['name'], op: ComponentOptionalProperties = {}) {
     this.#bomRef = new BomRef(op.bomRef)
     this.type = type
     this.name = name

--- a/src/models/component.ts
+++ b/src/models/component.ts
@@ -31,7 +31,7 @@ import { OrganizationalEntity } from './organizationalEntity'
 import { PropertyRepository } from './property'
 import { SWID } from './swid'
 
-interface ComponentOptionalProperties {
+interface OptionalComponentProperties {
   bomRef?: BomRef['value']
   author?: Component['author']
   copyright?: Component['copyright']
@@ -81,7 +81,7 @@ export class Component implements Comparable<Component> {
   /**
    * @throws {TypeError} if {@link op.cpe} is neither {@link CPE} nor {@link undefined}
    */
-  constructor (type: Component['type'], name: Component['name'], op: ComponentOptionalProperties = {}) {
+  constructor (type: Component['type'], name: Component['name'], op: OptionalComponentProperties = {}) {
     this.#bomRef = new BomRef(op.bomRef)
     this.type = type
     this.name = name

--- a/src/models/externalReference.ts
+++ b/src/models/externalReference.ts
@@ -20,7 +20,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 import { Comparable, SortableComparables } from '../_helpers/sortable'
 import { ExternalReferenceType } from '../enums'
 
-export interface ExternalReferenceOptionalProperties {
+export interface OptionalExternalReferenceProperties {
   comment?: ExternalReference['comment']
 }
 
@@ -29,7 +29,7 @@ export class ExternalReference implements Comparable<ExternalReference> {
   type: ExternalReferenceType
   comment?: string
 
-  constructor (url: ExternalReference['url'], type: ExternalReference['type'], op: ExternalReferenceOptionalProperties = {}) {
+  constructor (url: ExternalReference['url'], type: ExternalReference['type'], op: OptionalExternalReferenceProperties = {}) {
     this.url = url
     this.type = type
     this.comment = op.comment

--- a/src/models/externalReference.ts
+++ b/src/models/externalReference.ts
@@ -20,7 +20,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 import { Comparable, SortableComparables } from '../_helpers/sortable'
 import { ExternalReferenceType } from '../enums'
 
-interface OptionalProperties {
+export interface ExternalReferenceOptionalProperties {
   comment?: ExternalReference['comment']
 }
 
@@ -29,7 +29,7 @@ export class ExternalReference implements Comparable<ExternalReference> {
   type: ExternalReferenceType
   comment?: string
 
-  constructor (url: ExternalReference['url'], type: ExternalReference['type'], op: OptionalProperties = {}) {
+  constructor (url: ExternalReference['url'], type: ExternalReference['type'], op: ExternalReferenceOptionalProperties = {}) {
     this.url = url
     this.type = type
     this.comment = op.comment

--- a/src/models/license.ts
+++ b/src/models/license.ts
@@ -59,7 +59,7 @@ export class LicenseExpression {
   }
 }
 
-interface NamedLicenseOptionalProperties {
+export interface NamedLicenseOptionalProperties {
   text?: NamedLicense['text']
   url?: NamedLicense['url']
 }
@@ -80,7 +80,7 @@ export class NamedLicense {
   }
 }
 
-interface SpdxLicenseOptionalProperties {
+export interface SpdxLicenseOptionalProperties {
   text?: SpdxLicense['text']
   url?: SpdxLicense['url']
 }

--- a/src/models/license.ts
+++ b/src/models/license.ts
@@ -59,7 +59,7 @@ export class LicenseExpression {
   }
 }
 
-export interface NamedLicenseOptionalProperties {
+export interface OptionalNamedLicenseProperties {
   text?: NamedLicense['text']
   url?: NamedLicense['url']
 }
@@ -69,7 +69,7 @@ export class NamedLicense {
   text?: Attachment
   url?: URL | string
 
-  constructor (name: NamedLicense['name'], op: NamedLicenseOptionalProperties = {}) {
+  constructor (name: NamedLicense['name'], op: OptionalNamedLicenseProperties = {}) {
     this.name = name
     this.text = op.text
     this.url = op.url
@@ -80,7 +80,7 @@ export class NamedLicense {
   }
 }
 
-export interface SpdxLicenseOptionalProperties {
+export interface OptionalSpdxLicenseProperties {
   text?: SpdxLicense['text']
   url?: SpdxLicense['url']
 }
@@ -95,7 +95,7 @@ export class SpdxLicense {
   /**
    * @throws {RangeError} if {@link id} is not supported SPDX id({@link isSupportedSpdxId})
    */
-  constructor (id: SpdxLicense['id'], op: SpdxLicenseOptionalProperties = {}) {
+  constructor (id: SpdxLicense['id'], op: OptionalSpdxLicenseProperties = {}) {
     this.id = id
     this.text = op.text
     this.url = op.url

--- a/src/models/metadata.ts
+++ b/src/models/metadata.ts
@@ -22,7 +22,7 @@ import { OrganizationalContactRepository } from './organizationalContact'
 import { OrganizationalEntity } from './organizationalEntity'
 import { ToolRepository } from './tool'
 
-export interface MetadataOptionalProperties {
+export interface OptionalMetadataProperties {
   timestamp?: Metadata['timestamp']
   tools?: Metadata['tools']
   authors?: Metadata['authors']
@@ -39,7 +39,7 @@ export class Metadata {
   manufacture?: OrganizationalEntity
   supplier?: OrganizationalEntity
 
-  constructor (op: MetadataOptionalProperties = {}) {
+  constructor (op: OptionalMetadataProperties = {}) {
     this.timestamp = op.timestamp
     this.tools = op.tools ?? new ToolRepository()
     this.authors = op.authors ?? new OrganizationalContactRepository()

--- a/src/models/metadata.ts
+++ b/src/models/metadata.ts
@@ -22,7 +22,7 @@ import { OrganizationalContactRepository } from './organizationalContact'
 import { OrganizationalEntity } from './organizationalEntity'
 import { ToolRepository } from './tool'
 
-interface OptionalProperties {
+export interface MetadataOptionalProperties {
   timestamp?: Metadata['timestamp']
   tools?: Metadata['tools']
   authors?: Metadata['authors']
@@ -39,7 +39,7 @@ export class Metadata {
   manufacture?: OrganizationalEntity
   supplier?: OrganizationalEntity
 
-  constructor (op: OptionalProperties = {}) {
+  constructor (op: MetadataOptionalProperties = {}) {
     this.timestamp = op.timestamp
     this.tools = op.tools ?? new ToolRepository()
     this.authors = op.authors ?? new OrganizationalContactRepository()

--- a/src/models/organizationalContact.ts
+++ b/src/models/organizationalContact.ts
@@ -19,7 +19,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 
 import { Comparable, SortableComparables } from '../_helpers/sortable'
 
-export interface OrganizationalContactOptionalProperties {
+export interface OptionalOrganizationalContactProperties {
   name?: OrganizationalContact['name']
   email?: OrganizationalContact['email']
   phone?: OrganizationalContact['phone']
@@ -30,7 +30,7 @@ export class OrganizationalContact implements Comparable<OrganizationalContact> 
   email?: string
   phone?: string
 
-  constructor (op: OrganizationalContactOptionalProperties = {}) {
+  constructor (op: OptionalOrganizationalContactProperties = {}) {
     this.name = op.name
     this.email = op.email
     this.phone = op.phone

--- a/src/models/organizationalContact.ts
+++ b/src/models/organizationalContact.ts
@@ -19,7 +19,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 
 import { Comparable, SortableComparables } from '../_helpers/sortable'
 
-interface OptionalProperties {
+export interface OrganizationalContactOptionalProperties {
   name?: OrganizationalContact['name']
   email?: OrganizationalContact['email']
   phone?: OrganizationalContact['phone']
@@ -30,7 +30,7 @@ export class OrganizationalContact implements Comparable<OrganizationalContact> 
   email?: string
   phone?: string
 
-  constructor (op: OptionalProperties = {}) {
+  constructor (op: OrganizationalContactOptionalProperties = {}) {
     this.name = op.name
     this.email = op.email
     this.phone = op.phone

--- a/src/models/organizationalEntity.ts
+++ b/src/models/organizationalEntity.ts
@@ -19,7 +19,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 
 import { OrganizationalContactRepository } from './organizationalContact'
 
-export interface OrganizationalEntityOptionalProperties {
+export interface OptionalOrganizationalEntityProperties {
   name?: OrganizationalEntity['name']
   url?: OrganizationalEntity['url']
   contact?: OrganizationalEntity['contact']
@@ -30,7 +30,7 @@ export class OrganizationalEntity {
   url: Set<URL | string>
   contact: OrganizationalContactRepository
 
-  constructor (op: OrganizationalEntityOptionalProperties = {}) {
+  constructor (op: OptionalOrganizationalEntityProperties = {}) {
     this.name = op.name
     this.url = op.url ?? new Set()
     this.contact = op.contact ?? new OrganizationalContactRepository()

--- a/src/models/organizationalEntity.ts
+++ b/src/models/organizationalEntity.ts
@@ -19,7 +19,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 
 import { OrganizationalContactRepository } from './organizationalContact'
 
-interface OptionalProperties {
+export interface OrganizationalEntityOptionalProperties {
   name?: OrganizationalEntity['name']
   url?: OrganizationalEntity['url']
   contact?: OrganizationalEntity['contact']
@@ -30,7 +30,7 @@ export class OrganizationalEntity {
   url: Set<URL | string>
   contact: OrganizationalContactRepository
 
-  constructor (op: OptionalProperties = {}) {
+  constructor (op: OrganizationalEntityOptionalProperties = {}) {
     this.name = op.name
     this.url = op.url ?? new Set()
     this.contact = op.contact ?? new OrganizationalContactRepository()

--- a/src/models/swid.ts
+++ b/src/models/swid.ts
@@ -20,7 +20,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 import { isNonNegativeInteger, NonNegativeInteger } from '../types'
 import { Attachment } from './attachment'
 
-interface OptionalProperties {
+export interface SWIDOptionalProperties {
   version?: SWID['version']
   patch?: SWID['patch']
   text?: SWID['text']
@@ -45,7 +45,7 @@ export class SWID {
   /**
    * @throws {TypeError} if {@link op.tagVersion} is neither {@link NonNegativeInteger} nor {@link undefined}
    */
-  constructor (tagId: SWID['tagId'], name: SWID['name'], op: OptionalProperties = {}) {
+  constructor (tagId: SWID['tagId'], name: SWID['name'], op: SWIDOptionalProperties = {}) {
     this.tagId = tagId
     this.name = name
     this.version = op.version

--- a/src/models/swid.ts
+++ b/src/models/swid.ts
@@ -20,7 +20,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 import { isNonNegativeInteger, NonNegativeInteger } from '../types'
 import { Attachment } from './attachment'
 
-export interface SWIDOptionalProperties {
+export interface OptionalSWIDProperties {
   version?: SWID['version']
   patch?: SWID['patch']
   text?: SWID['text']
@@ -45,7 +45,7 @@ export class SWID {
   /**
    * @throws {TypeError} if {@link op.tagVersion} is neither {@link NonNegativeInteger} nor {@link undefined}
    */
-  constructor (tagId: SWID['tagId'], name: SWID['name'], op: SWIDOptionalProperties = {}) {
+  constructor (tagId: SWID['tagId'], name: SWID['name'], op: OptionalSWIDProperties = {}) {
     this.tagId = tagId
     this.name = name
     this.version = op.version

--- a/src/models/tool.ts
+++ b/src/models/tool.ts
@@ -21,7 +21,7 @@ import { Comparable, SortableComparables } from '../_helpers/sortable'
 import { ExternalReferenceRepository } from './externalReference'
 import { HashDictionary } from './hash'
 
-interface OptionalProperties {
+export interface ToolOptionalProperties {
   vendor?: Tool['vendor']
   name?: Tool['name']
   version?: Tool['version']
@@ -36,7 +36,7 @@ export class Tool implements Comparable<Tool> {
   hashes: HashDictionary
   externalReferences: ExternalReferenceRepository
 
-  constructor (op: OptionalProperties = {}) {
+  constructor (op: ToolOptionalProperties = {}) {
     this.vendor = op.vendor
     this.name = op.name
     this.version = op.version

--- a/src/models/tool.ts
+++ b/src/models/tool.ts
@@ -21,7 +21,7 @@ import { Comparable, SortableComparables } from '../_helpers/sortable'
 import { ExternalReferenceRepository } from './externalReference'
 import { HashDictionary } from './hash'
 
-export interface ToolOptionalProperties {
+export interface OptionalToolProperties {
   vendor?: Tool['vendor']
   name?: Tool['name']
   version?: Tool['version']
@@ -36,7 +36,7 @@ export class Tool implements Comparable<Tool> {
   hashes: HashDictionary
   externalReferences: ExternalReferenceRepository
 
-  constructor (op: ToolOptionalProperties = {}) {
+  constructor (op: OptionalToolProperties = {}) {
     this.vendor = op.vendor
     this.name = op.name
     this.version = op.version


### PR DESCRIPTION
fixes #439

- prefix all `OptionalProperties` with the target - ala `OptionalSpdxLicenseProperties`
- export them OptionalProperties