### PR TITLE
docs: describe how to install from source with `pnpm`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ written in _TypeScript_ and compiled for the target.
 
 ## Installation
 
-This package and the build results are available for _npm_, _yarn_ and _pnpm_:
+This package and the build results are available for _npm_, _pnpm_ and _yarn_:
 
 ```shell
 npm i -S @cyclonedx/cyclonedx-library
-yarn add @cyclonedx/cyclonedx-library
 pnpm add @cyclonedx/cyclonedx-library
+yarn add @cyclonedx/cyclonedx-library
 ```
 
 You can install the package from source,
@@ -105,8 +105,8 @@ which will build automatically on installation:
 
 ```shell
 npm i -S github:CycloneDX/cyclonedx-javascript-library
+pnpm add github:CycloneDX/cyclonedx-javascript-library
 # not supported with yarn
-# not supported with pnpm
 ```
 
 ## Usage


### PR DESCRIPTION
`pnpm` finally got working support to install packages form GitHub and run the `prepublish` scripts, that are needed to compile the TypeScript of this package in install-time.

so let's document this.