### PR TITLE
docs: describe how to install from source with `yarn2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ which will build automatically on installation:
 ```shell
 npm i -S github:CycloneDX/cyclonedx-javascript-library
 pnpm add github:CycloneDX/cyclonedx-javascript-library
-# not supported with yarn
+yarn add @cyclonedx/cyclonedx-library@github:CycloneDX/cyclonedx-javascript-library # only with yarn-2
 ```
 
 ## Usage


### PR DESCRIPTION
yarn2 (`yarn init -2`) finally has working support to install from source and run all needed `prepublish` scripts in install-time.

let's document this. 