### PR TITLE
ci: remove unnessessarry error-prone tests for type digest

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -139,8 +139,8 @@ jobs:
         include:
           - # latest 4.X
             typescript-version: '^4'
-          - # some 4.0.x
-            typescript-version: '~4.0'
+          # - # some 4.0.x
+          #  typescript-version: '~4.0'
           - # latest 3.X
             typescript-version: '^3'
             nodeTypes-version: '^16'


### PR DESCRIPTION
some tests keep on crashing ... https://github.com/CycloneDX/cyclonedx-javascript-library/actions/runs/4270034656/jobs/7433604150 

but these testst are not actually required ... 