### PR TITLE
Xmlserializer public normalizers for vuln

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,12 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+* Changed
+  * Classes `Serialize.Xml.Normalize.Vulnerability*Normalizer` are now public available (via [#])  
+    Previously, they were only available via `Serialize.Xml.Normalize.Factory.makeForVulnerability*()`.
 * Build
   * Use _TypeScript_ `v5.1.3` now, was `v5.0.4`. (via [#790])
   * Use _Webpack_ `v5.82.1` now, was `v5.80.0`. (via [#802])
 
 [#790]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/790
 [#802]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/802
+[#]:
 
 ## 2.0.0 -- 2023-05-17
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## unreleased
 
 * Changed
-  * Classes `Serialize.Xml.Normalize.Vulnerability*Normalizer` are now public available (via [#])  
+  * Classes `Serialize.Xml.Normalize.Vulnerability*Normalizer` are now public available (via [#816])  
     Previously, they were only available via `Serialize.Xml.Normalize.Factory.makeForVulnerability*()`.
 * Build
   * Use _TypeScript_ `v5.1.3` now, was `v5.0.4`. (via [#790])
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 [#790]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/790
 [#802]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/802
-[#]:
+[#816]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/816
 
 ## 2.0.0 -- 2023-05-17
 

--- a/src/serialize/xml/normalize.ts
+++ b/src/serialize/xml/normalize.ts
@@ -724,7 +724,7 @@ export class DependencyGraphNormalizer extends BaseXmlNormalizer<Models.Bom> {
   }
 }
 
-class VulnerabilityNormalizer extends BaseXmlNormalizer<Models.Vulnerability.Vulnerability> {
+export class VulnerabilityNormalizer extends BaseXmlNormalizer<Models.Vulnerability.Vulnerability> {
   normalize (data: Models.Vulnerability.Vulnerability, options: NormalizerOptions, elementName: string): SimpleXml.Element {
     const references: SimpleXml.Element | undefined = data.references.size > 0
       ? {
@@ -820,7 +820,7 @@ class VulnerabilityNormalizer extends BaseXmlNormalizer<Models.Vulnerability.Vul
   }
 }
 
-class VulnerabilitySourceNormalizer extends BaseXmlNormalizer<Models.Vulnerability.Source> {
+export class VulnerabilitySourceNormalizer extends BaseXmlNormalizer<Models.Vulnerability.Source> {
   normalize (data: Models.Vulnerability.Source, options: NormalizerOptions, elementName: string): SimpleXml.Element {
     const url = data.url?.toString()
     return {
@@ -836,7 +836,7 @@ class VulnerabilitySourceNormalizer extends BaseXmlNormalizer<Models.Vulnerabili
   }
 }
 
-class VulnerabilityReferenceNormalizer extends BaseXmlNormalizer<Models.Vulnerability.Reference> {
+export class VulnerabilityReferenceNormalizer extends BaseXmlNormalizer<Models.Vulnerability.Reference> {
   normalize (data: Models.Vulnerability.Reference, options: NormalizerOptions, elementName: string): SimpleXml.Element {
     return {
       type: 'element',
@@ -857,7 +857,7 @@ class VulnerabilityReferenceNormalizer extends BaseXmlNormalizer<Models.Vulnerab
   }
 }
 
-class VulnerabilityRatingNormalizer extends BaseXmlNormalizer<Models.Vulnerability.Rating> {
+export class VulnerabilityRatingNormalizer extends BaseXmlNormalizer<Models.Vulnerability.Rating> {
   normalize (data: Models.Vulnerability.Rating, options: NormalizerOptions, elementName: string): SimpleXml.Element {
     return {
       type: 'element',
@@ -884,7 +884,7 @@ class VulnerabilityRatingNormalizer extends BaseXmlNormalizer<Models.Vulnerabili
   }
 }
 
-class VulnerabilityAdvisoryNormalizer extends BaseXmlNormalizer<Models.Vulnerability.Advisory> {
+export class VulnerabilityAdvisoryNormalizer extends BaseXmlNormalizer<Models.Vulnerability.Advisory> {
   normalize (data: Models.Vulnerability.Advisory, options: NormalizerOptions, elementName: string): SimpleXml.Element | undefined {
     const url = data.url.toString()
     if (!XmlSchema.isAnyURI(url)) {
@@ -912,7 +912,7 @@ class VulnerabilityAdvisoryNormalizer extends BaseXmlNormalizer<Models.Vulnerabi
   }
 }
 
-class VulnerabilityCreditsNormalizer extends BaseXmlNormalizer<Models.Vulnerability.Credits> {
+export class VulnerabilityCreditsNormalizer extends BaseXmlNormalizer<Models.Vulnerability.Credits> {
   normalize (data: Models.Vulnerability.Credits, options: NormalizerOptions, elementName: string): SimpleXml.Element {
     const organizations: SimpleXml.Element | undefined = data.organizations.size > 0
       ? {
@@ -939,7 +939,7 @@ class VulnerabilityCreditsNormalizer extends BaseXmlNormalizer<Models.Vulnerabil
   }
 }
 
-class VulnerabilityAnalysisNormalizer extends BaseXmlNormalizer<Models.Vulnerability.Analysis> {
+export class VulnerabilityAnalysisNormalizer extends BaseXmlNormalizer<Models.Vulnerability.Analysis> {
   normalize (data: Models.Vulnerability.Analysis, options: NormalizerOptions, elementName: string): SimpleXml.Element {
     const responses: SimpleXml.Element | undefined = data.response.size > 0
       ? {
@@ -965,7 +965,7 @@ class VulnerabilityAnalysisNormalizer extends BaseXmlNormalizer<Models.Vulnerabi
   }
 }
 
-class VulnerabilityAffectNormalizer extends BaseXmlNormalizer<Models.Vulnerability.Affect> {
+export class VulnerabilityAffectNormalizer extends BaseXmlNormalizer<Models.Vulnerability.Affect> {
   normalize (data: Models.Vulnerability.Affect, options: NormalizerOptions, elementName: string): SimpleXml.Element {
     const versions: SimpleXml.Element | undefined = data.versions.size > 0
       ? {
@@ -993,7 +993,7 @@ class VulnerabilityAffectNormalizer extends BaseXmlNormalizer<Models.Vulnerabili
   }
 }
 
-class VulnerabilityAffectedVersionNormalizer extends BaseXmlNormalizer<Models.Vulnerability.AffectedVersion> {
+export class VulnerabilityAffectedVersionNormalizer extends BaseXmlNormalizer<Models.Vulnerability.AffectedVersion> {
   normalize (data: Models.Vulnerability.AffectedVersion, options: NormalizerOptions, elementName: string): SimpleXml.Element {
     switch (true) {
       case data instanceof Models.Vulnerability.AffectedSingleVersion:


### PR DESCRIPTION
  * Classes `Serialize.Xml.Normalize.Vulnerability*Normalizer` are now public available  
    Previously, they were only available via `Serialize.Xml.Normalize.Factory.makeForVulnerability*()`.