### PR TITLE
docs: fix jsdoc warning from eslint foo

### DIFF
--- a/libs/universal-node-xml/stringifiers/xmlbuilder2.js
+++ b/libs/universal-node-xml/stringifiers/xmlbuilder2.js
@@ -57,7 +57,7 @@ function stringify (element, { space } = {}) {
 /**
  * @param {XMLBuilder} parent
  * @param {Element} element
- * @param {string|null} [parentNS=null]
+ * @param {?string} [parentNS]
  */
 function addEle (parent, element, parentNS = null) {
   if (element.type !== 'element') { return }


### PR DESCRIPTION
fixes

> Check warning on line 60 in libs/universal-node-xml/stringifiers/xmlbuilder2.js
GitHub Actions / test standard
> 
> Defaults are not permitted on @param. (jsdoc/no-defaults)

