### PR TITLE
feat:  XML Validator prevent parsing XXE

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -119,6 +119,10 @@ jobs:
           - ubuntu-latest
           - macos-13 # macos-latest has issues with node14
           - windows-latest
+        includes:
+          - #
+            node-version: 20
+            os: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -119,10 +119,6 @@ jobs:
           - ubuntu-latest
           - macos-13 # macos-latest has issues with node14
           - windows-latest
-        includes:
-          - #
-            node-version: 20
-            os: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 <!-- add unreleased items here -->
 
+* Changed
+  * XmlValidation no longer supports XML external entities (via [#1063]; concerns [#1061])  
+    This is considered a security measure to prevent XML external entity (XXE) injection.
+
+[#1061]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/1061
+[#1063]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/1063
+
 ## 6.6.1 -- 2024-05-06
 
 * Fixed

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 <!-- add unreleased items here -->
 
 * Changed
-  * XmlValidation no longer supports XML external entities (via [#1063]; concerns [#1061])  
+  * The provided XML validation capabilities no longer supports external entities (via [#1063]; concerns [#1061])  
     This is considered a security measure to prevent XML external entity (XXE) injection.
 
 [#1061]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/1061

--- a/src/validation/xmlValidator.node.ts
+++ b/src/validation/xmlValidator.node.ts
@@ -48,7 +48,8 @@ async function getParser (): Promise<typeof parseXml> {
 
 const xmlParseOptions: Readonly<ParserOptions> = Object.freeze({
   nonet: true,
-  compact: true
+  compact: true,
+  noent: true // prevent https://github.com/CycloneDX/cyclonedx-javascript-library/issues/1061
 })
 
 export class XmlValidator extends BaseValidator {

--- a/tests/integration/Validation.XmlValidator.test.js
+++ b/tests/integration/Validation.XmlValidator.test.js
@@ -99,5 +99,47 @@ describe('Validation.XmlValidator', () => {
       const validationError = await validator.validate(input)
       assert.strictEqual(validationError, null)
     })
+
+    it('is not vulnerable to advisories/GHSA-mjr4-7xg5-pfvh', async  () => {
+      /* report:
+      see https://github.com/advisories/GHSA-mjr4-7xg5-pfvh
+      see https://github.com/CycloneDX/cyclonedx-javascript-library/issues/1061
+      */
+      const validator = new XmlValidator(version)
+      /* POC payload:
+      see https://research.jfrog.com/vulnerabilities/libxmljs2-attrs-type-confusion-rce-jfsa-2024-001034097/#poc
+       */
+      const input = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE note
+[
+<!ENTITY writer "` + 'A'.repeat(0x1234) + `">
+]>
+<from>&writer;</from>
+`;
+      const validationError = await validator.validate(input)
+      // expected to not crash ...
+      assert.strictEqual(validationError, null)
+    })
+
+    it('is not vulnerable to advisories/GHSA-78h3-pg4x-j8cv', async  () => {
+      /* report:
+      see https://github.com/advisories/GHSA-78h3-pg4x-j8cv
+      see https://github.com/CycloneDX/cyclonedx-javascript-library/issues/1061
+      */
+      const validator = new XmlValidator(version)
+      /* POC payload:
+      see https://research.jfrog.com/vulnerabilities/libxmljs2-namespaces-type-confusion-rce-jfsa-2024-001034098/#poc
+      */
+      const input = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE note
+[
+<!ENTITY writer PUBLIC "` + "A".repeat(8) + "B".repeat(8) + "C".repeat(8) + "D".repeat(8) + "P".repeat(8) + `" "JFrog Security">
+]>
+<from>&writer;</from>
+`;
+      const validationError = await validator.validate(input)
+      // expected to not crash ...
+      assert.strictEqual(validationError, null)
+    })
   }))
 })

--- a/tests/integration/Validation.XmlValidator.test.js
+++ b/tests/integration/Validation.XmlValidator.test.js
@@ -100,7 +100,7 @@ describe('Validation.XmlValidator', () => {
       assert.strictEqual(validationError, null)
     })
 
-    it('is not vulnerable to advisories/GHSA-mjr4-7xg5-pfvh', async  () => {
+    it('is not vulnerable to advisories/GHSA-mjr4-7xg5-pfvh', async () => {
       /* report:
       see https://github.com/advisories/GHSA-mjr4-7xg5-pfvh
       see https://github.com/CycloneDX/cyclonedx-javascript-library/issues/1061
@@ -126,7 +126,7 @@ describe('Validation.XmlValidator', () => {
       assert.strictEqual(validationError, null)
     })
 
-    it('is not vulnerable to advisories/GHSA-78h3-pg4x-j8cv', async  () => {
+    it('is not vulnerable to advisories/GHSA-78h3-pg4x-j8cv', async () => {
       /* report:
       see https://github.com/advisories/GHSA-78h3-pg4x-j8cv
       see https://github.com/CycloneDX/cyclonedx-javascript-library/issues/1061
@@ -138,7 +138,7 @@ describe('Validation.XmlValidator', () => {
       const input = `<?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE note
         [
-        <!ENTITY writer PUBLIC "` + "A".repeat(8) + "B".repeat(8) + "C".repeat(8) + "D".repeat(8) + "P".repeat(8) + `" "JFrog Security">
+        <!ENTITY writer PUBLIC "` + 'A'.repeat(8) + 'B'.repeat(8) + 'C'.repeat(8) + 'D'.repeat(8) + 'P'.repeat(8) + `" "JFrog Security">
         ]>
         <bom xmlns="http://cyclonedx.org/schema/bom/${version}">
           <components>

--- a/tests/integration/Validation.XmlValidator.test.js
+++ b/tests/integration/Validation.XmlValidator.test.js
@@ -119,6 +119,7 @@ describe('Validation.XmlValidator', () => {
             <component type="library">
               <name>&writer;</name><!-- << XML external entity (XXE) injection -->
               <version>1.337</version>
+              ${version === '1.0' ? '<modified>false</modified>' : ''}
             </component>
           </components>
         </bom>`
@@ -145,6 +146,7 @@ describe('Validation.XmlValidator', () => {
             <component type="library">
               <name>&writer;</name><!-- << XML external entity (XXE) injection -->
               <version>1.337</version>
+              ${version === '1.0' ? '<modified>false</modified>' : ''}
             </component>
           </components>
         </bom>`

--- a/tests/integration/Validation.XmlValidator.test.js
+++ b/tests/integration/Validation.XmlValidator.test.js
@@ -110,14 +110,19 @@ describe('Validation.XmlValidator', () => {
       see https://research.jfrog.com/vulnerabilities/libxmljs2-attrs-type-confusion-rce-jfsa-2024-001034097/#poc
        */
       const input = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE note
-[
-<!ENTITY writer "` + 'A'.repeat(0x1234) + `">
-]>
-<from>&writer;</from>
-`;
+        <!DOCTYPE note
+        [
+        <!ENTITY writer "` + 'A'.repeat(0x1234) + `">
+        ]>
+        <bom xmlns="http://cyclonedx.org/schema/bom/${version}">
+          <components>
+            <component type="library">
+              <name>&writer;</name><!-- << XML external entity (XXE) injection -->
+              <version>1.337</version>
+            </component>
+          </components>
+        </bom>`
       const validationError = await validator.validate(input)
-      // expected to not crash ...
       assert.strictEqual(validationError, null)
     })
 
@@ -131,14 +136,19 @@ describe('Validation.XmlValidator', () => {
       see https://research.jfrog.com/vulnerabilities/libxmljs2-namespaces-type-confusion-rce-jfsa-2024-001034098/#poc
       */
       const input = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE note
-[
-<!ENTITY writer PUBLIC "` + "A".repeat(8) + "B".repeat(8) + "C".repeat(8) + "D".repeat(8) + "P".repeat(8) + `" "JFrog Security">
-]>
-<from>&writer;</from>
-`;
+        <!DOCTYPE note
+        [
+        <!ENTITY writer PUBLIC "` + "A".repeat(8) + "B".repeat(8) + "C".repeat(8) + "D".repeat(8) + "P".repeat(8) + `" "JFrog Security">
+        ]>
+        <bom xmlns="http://cyclonedx.org/schema/bom/${version}">
+          <components>
+            <component type="library">
+              <name>&writer;</name><!-- << XML external entity (XXE) injection -->
+              <version>1.337</version>
+            </component>
+          </components>
+        </bom>`
       const validationError = await validator.validate(input)
-      // expected to not crash ...
       assert.strictEqual(validationError, null)
     })
   }))


### PR DESCRIPTION
prevent the XmlValidation from XXE parsing - prevent XML external entity (XXE) injection
This is considered a security measure. 

fixes #1061 as described here: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/1063#issuecomment-2098335774
