### PR TITLE
refactor: XML validator explicitely harden against XXE injections

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,11 +7,11 @@ All notable changes to this project will be documented in this file.
 <!-- add unreleased items here -->
 
 * Changed
-  * The provided XML validation capabilities are hardened (via [#]; concerns [#1061])  
+  * The provided XML validation capabilities are hardened (via [#1064]; concerns [#1061])  
     This is considered a security measure concerning XML external entity (XXE) injection.
 
 [#1061]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/1061
-[#]:
+[#1064]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/1064
 
 ## 6.7.1 -- 2024-05-07
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 <!-- add unreleased items here -->
 
+* Changed
+  * The provided XML validation capabilities are hardened (via [#]; concerns [#1061])  
+    This is considered a security measure concerning XML external entity (XXE) injection.
+
+[#1061]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/1061
+[#]:
+
 ## 6.7.1 -- 2024-05-07
 
 Reverted v6.7.0, back to v6.6.1

--- a/src/validation/xmlValidator.node.ts
+++ b/src/validation/xmlValidator.node.ts
@@ -48,7 +48,11 @@ async function getParser (): Promise<typeof parseXml> {
 
 const xmlParseOptions: Readonly<ParserOptions> = Object.freeze({
   nonet: true,
-  compact: true
+  compact: true,
+  // explicitly prevent XXE
+  // see https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
+  noent: false,
+  dtdload: false
 })
 
 export class XmlValidator extends BaseValidator {

--- a/tests/_data/xxe_flag.txt
+++ b/tests/_data/xxe_flag.txt
@@ -1,0 +1,5 @@
+This file is target of a XXE injection test, that is expected to fail.
+
+The secret flag is:
+
+vaiquia2zoo3Im8ro9zahNg5mohwipouka2xieweed6ahChei3doox2fek3ise0lmohju3loh5oDu7eigh3jaeR2aiph2Voo

--- a/tests/_data/xxe_flag.txt
+++ b/tests/_data/xxe_flag.txt
@@ -1,5 +1,4 @@
-This file is target of a XXE injection test, that is expected to fail.
-
-The secret flag is:
+This file is target of XXE injection tests.
+The flag is:
 
 vaiquia2zoo3Im8ro9zahNg5mohwipouka2xieweed6ahChei3doox2fek3ise0lmohju3loh5oDu7eigh3jaeR2aiph2Voo

--- a/tests/integration/Validation.XmlValidator.test.js
+++ b/tests/integration/Validation.XmlValidator.test.js
@@ -18,8 +18,8 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
 const assert = require('assert')
-const { join } = require('path')
 const { realpathSync } = require('fs')
+const { join } = require('path')
 const { pathToFileURL } = require('url')
 
 const { describe, it } = require('mocha')


### PR DESCRIPTION
## Changed
  * The provided XML validation capabilities are hardened (via [#1064]; concerns [#1061])  
    This is considered a security measure concerning XML external entity (XXE) injection.

[#1061]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/1061
[#1064]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/1064

----

This is not an actual change. 
Per default, the XML validation capabilities were already secure in the intended ways.
This is to prevent the fuckup like in the yanked v6.7.0
