### PR TITLE
fix: `PackageUrlFactory` generic default

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 <!-- add unreleased items here -->
 
+## 6.8.2 -- 2024-05-21
+
+* Fixed
+  * Added `Factories.PackageUrlFactory`'s generic default back in (via [#1076])
+
+[#1076]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/1076
+
 ## 6.8.1 -- 2024-05-21
 
 * Fixed

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 ## 6.8.2 -- 2024-05-21
 
 * Fixed
-  * Added `Factories.PackageUrlFactory`'s generic default back in (via [#1076])
+  * Added `Factories.PackageUrlFactory`'s generic type's default back in (via [#1076])
 
 [#1076]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/1076
 

--- a/src/factories/packageUrl.ts
+++ b/src/factories/packageUrl.ts
@@ -23,7 +23,7 @@ import { PackageUrlQualifierNames } from '../_helpers/packageUrl'
 import { ExternalReferenceType } from '../enums/externalReferenceType'
 import type { Component } from '../models/component'
 
-export class PackageUrlFactory<PurlType extends PackageURL['type']> {
+export class PackageUrlFactory<PurlType extends PackageURL['type'] = PackageURL['type']> {
   readonly #type: PurlType
 
   constructor (type: PurlType) {


### PR DESCRIPTION
## Fixed
  * Added `Factories.PackageUrlFactory`'s generic type's default back in