### PR TITLE
[WIP] feat: `Builders.FromPath.LicenseEvidenceBuilder`

### DIFF
--- a/src/_helpers/mime.ts
+++ b/src/_helpers/mime.ts
@@ -17,5 +17,21 @@ SPDX-License-Identifier: Apache-2.0
 Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
-export * as FromNodePackageJson from './fromNodePackageJson.node'
-export * as FromPath from './fromPath.node'
+
+import {extname} from "path";
+
+export type MimeType = string
+
+const MAP_TEXT_EXTENSION_MIME: Readonly<Record<string, MimeType>> = {
+  '': 'text/plain',
+  '.licence': 'text/plain',
+  '.license': 'text/plain',
+  '.md': 'text/markdown',
+  '.rst': 'text/prs.fallenstein.rst',
+  '.txt': 'text/plain',
+  '.xml': 'text/xml' // not `application/xml` -- our scope is text!
+} as const
+
+export function getMimeForTextFile (filename: string): MimeType | undefined {
+  return MAP_TEXT_EXTENSION_MIME[extname(filename).toLowerCase()]
+}

--- a/src/_helpers/mime.ts
+++ b/src/_helpers/mime.ts
@@ -20,10 +20,13 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 
 import {extname} from "path";
 
-export type MimeType = string
+import type {MimeType} from "../types/mimeType";
 
 const MAP_TEXT_EXTENSION_MIMETYPE: Readonly<Record<string, MimeType>> = {
   '': 'text/plain', // our scope is text!
+  '.csv': 'text/csv',
+  '.htm': 'text/html',
+  '.html': 'text/html',
   '.licence': 'text/plain',
   '.license': 'text/plain',
   '.md': 'text/markdown',
@@ -32,6 +35,10 @@ const MAP_TEXT_EXTENSION_MIMETYPE: Readonly<Record<string, MimeType>> = {
   '.xml': 'text/xml' // not `application/xml` -- our scope is text!
 } as const
 
+/**
+ * Returns the guessed mime type of file, based on file name extension.
+ * Returns undefined if tile extension is unknown.
+ */
 export function getMimeTypeForTextFile (filename: string): MimeType | undefined {
   return MAP_TEXT_EXTENSION_MIMETYPE[extname(filename).toLowerCase()]
 }

--- a/src/_helpers/mime.ts
+++ b/src/_helpers/mime.ts
@@ -22,8 +22,8 @@ import {extname} from "path";
 
 export type MimeType = string
 
-const MAP_TEXT_EXTENSION_MIME: Readonly<Record<string, MimeType>> = {
-  '': 'text/plain',
+const MAP_TEXT_EXTENSION_MIMETYPE: Readonly<Record<string, MimeType>> = {
+  '': 'text/plain', // our scope is text!
   '.licence': 'text/plain',
   '.license': 'text/plain',
   '.md': 'text/markdown',
@@ -32,6 +32,6 @@ const MAP_TEXT_EXTENSION_MIME: Readonly<Record<string, MimeType>> = {
   '.xml': 'text/xml' // not `application/xml` -- our scope is text!
 } as const
 
-export function getMimeForTextFile (filename: string): MimeType | undefined {
-  return MAP_TEXT_EXTENSION_MIME[extname(filename).toLowerCase()]
+export function getMimeTypeForTextFile (filename: string): MimeType | undefined {
+  return MAP_TEXT_EXTENSION_MIMETYPE[extname(filename).toLowerCase()]
 }

--- a/src/builders/fromPath.node.ts
+++ b/src/builders/fromPath.node.ts
@@ -1,0 +1,110 @@
+/*!
+This file is part of CycloneDX JavaScript Library.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) OWASP Foundation. All Rights Reserved.
+*/
+
+/**
+ * Node-specifics.
+ */
+
+import {readdirSync, readFileSync} from "fs";
+import {join, relative, resolve} from "path";
+
+import {getMimeForTextFile} from "../_helpers/mime";
+import {AttachmentEncoding} from "../enums/attachmentEncoding";
+import {Attachment} from "../models/attachment";
+import {NamedLicense} from "../models/license";
+
+
+
+/**
+ * Node-specific LicenseEvidenceBuilder.
+ */
+export class LicenseEvidenceBuilder {
+
+  readonly #LICENSE_FILENAME_PATTERN = /^(?:UN)?LICEN[CS]E|.\.LICEN[CS]E$|^NOTICE$/i
+
+  /**
+   * Return a license on success, returns undefined if it appears to bes no known text file.
+   * Throws errors, if license attachment failed to create.
+   *
+   * @param file - path to file
+   * @param relativeFrom - path the file shall be relative to
+   * @returns {@link NamedLicense} on success
+   */
+  public fromFile(file: string, relativeFrom: string | undefined = undefined): NamedLicense | undefined {
+    const contentType = getMimeForTextFile(file)
+    if (contentType === undefined) {
+      return undefined
+    }
+    let lname
+    if ( relativeFrom === undefined) {
+      lname = `file: ${file}`
+    } else {
+      // `file` could be absolute or relative path - lets resolve it anyway
+      file = resolve(relativeFrom, file)
+      lname = `file: ${relative(relativeFrom, file)}`
+    }
+    return new NamedLicense(
+      `file: ${lname}`,
+      {
+        text: new Attachment(
+          // may throw if `readFileSync()` fails
+          readFileSync(file).toString('base64'),
+          {
+            contentType,
+            encoding: AttachmentEncoding.Base64
+          }
+        )
+      })
+  }
+
+  /**
+   * Returns a generator for license evidences.
+   * Throws errors, if dir cannot be inspected.
+   *
+   * @param dir - path to inspect
+   * @param relativeFrom - path the dir shall be relative to
+   */
+  public * fromDir(dir: string, relativeFrom: string | undefined = undefined): Generator<NamedLicense> {
+    if ( relativeFrom !== undefined) {
+      // `dir` could be absolute or relative path - lets resolve it anyway
+      dir = resolve(relativeFrom, dir)
+    }
+    // may throw if `readdirSync()` fails
+    const dcis = readdirSync(dir, { withFileTypes: true })
+    for (const dci of dcis) {
+      if (
+        !dci.isFile() ||
+        !this.#LICENSE_FILENAME_PATTERN.test(dci.name.toLowerCase())
+      ) {
+        continue
+      }
+
+      let le
+      try {
+        le = this.fromFile( join(dir, dci.name), relativeFrom)
+      } catch (e) {
+        continue
+      }
+      if (le !== undefined) {
+        yield le
+      }
+    }
+  }
+
+}

--- a/src/builders/fromPath.node.ts
+++ b/src/builders/fromPath.node.ts
@@ -22,7 +22,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 
 import {readdirSync} from "fs";
-import {join, relative, resolve} from "path";
+import {join, relative} from "path";
 
 import type * as Factories from "../factories/index.node";
 import {NamedLicense} from "../models/license";
@@ -48,6 +48,9 @@ export class LicenseEvidenceBuilder {
    * Return a license on success.
    * Returns undefined if it appears to bes no known text file.
    * Throws error, if license attachment content could not be fetched.
+   *
+   * If `relativeFrom` is given, the file is displayed relative from there,
+   * else the full file name is displayed.
    *
    * @param file - path to file
    * @param relativeFrom -  relative path reference for file display
@@ -77,6 +80,10 @@ export class LicenseEvidenceBuilder {
    *
    * @param dir - path to inspect
    * @param relativeFrom - relative path reference for file display
+   *
+   * @remarks
+   *
+   * Utilizes {@link fromFile}.
    */
   public * fromDir(dir: string, relativeFrom: string | undefined = undefined): Generator<NamedLicense> {
     // may throw if `readdirSync()` fails

--- a/src/builders/fromPath.node.ts
+++ b/src/builders/fromPath.node.ts
@@ -44,31 +44,31 @@ export class LicenseEvidenceBuilder {
 
   /**
    * Return a license on success, returns undefined if it appears to bes no known text file.
-   * Throws errors, if license attachment failed to create.
+   * Throws error, if license attachment content could not be fetched.
    *
    * @param file - path to file
    * @param relativeFrom - path the file shall be relative to
    * @returns {@link NamedLicense} on success
    */
   public fromFile(file: string, relativeFrom: string | undefined = undefined): NamedLicense | undefined {
-    let lname
+    let name
     if ( relativeFrom === undefined) {
-      lname = `file: ${file}`
+      name = `file: ${file}`
     } else {
       // `file` could be absolute or relative path - lets resolve it anyway
       file = resolve(relativeFrom, file)
-      lname = `file: ${relative(relativeFrom, file)}`
+      name = `file: ${relative(relativeFrom, file)}`
     }
     const text = this.#afac.fromTextFile(file)
     if (text === undefined) {
       return undefined
     }
-    return new NamedLicense(lname, {text})
+    return new NamedLicense(name, {text})
   }
 
   /**
    * Returns a generator for license evidences.
-   * Throws errors, if dir cannot be inspected.
+   * Throws error, if dir content could not be inspected.
    *
    * @param dir - path to inspect
    * @param relativeFrom - path the dir and files shall be relative to

--- a/src/builders/fromPath.node.ts
+++ b/src/builders/fromPath.node.ts
@@ -50,7 +50,7 @@ export class LicenseEvidenceBuilder {
    * Throws error, if license attachment content could not be fetched.
    *
    * @param file - path to file
-   * @param relativeFrom - path the file shall be relative from
+   * @param relativeFrom -  relative path reference for file display
    */
   public fromFile(file: string, relativeFrom: string | undefined = undefined): NamedLicense | undefined {
     let name
@@ -58,7 +58,6 @@ export class LicenseEvidenceBuilder {
       name = `file: ${file}`
     } else {
       // `file` could be absolute or relative path - lets resolve it anyway
-      file = resolve(relativeFrom, file)
       name = `file: ${relative(relativeFrom, file)}`
     }
     const text = this.#attachmentFactory.fromTextFile(file)
@@ -77,13 +76,9 @@ export class LicenseEvidenceBuilder {
    * Unreadable files will be omitted.
    *
    * @param dir - path to inspect
-   * @param relativeFrom - path the dir and files shall be relative from
+   * @param relativeFrom - relative path reference for file display
    */
   public * fromDir(dir: string, relativeFrom: string | undefined = undefined): Generator<NamedLicense> {
-    if ( relativeFrom !== undefined) {
-      // `dir` could be absolute or relative path - lets resolve it anyway
-      dir = resolve(relativeFrom, dir)
-    }
     // may throw if `readdirSync()` fails
     const dcis = readdirSync(dir, { withFileTypes: true })
     for (const dci of dcis) {

--- a/src/builders/fromPath.node.ts
+++ b/src/builders/fromPath.node.ts
@@ -50,7 +50,7 @@ export class LicenseEvidenceBuilder {
    * Throws error, if license attachment content could not be fetched.
    *
    * If `relativeFrom` is given, the file is displayed relative from there,
-   * else the full file name is displayed.
+   * else the file is displayed unmodified.
    *
    * @param file - path to file
    * @param relativeFrom -  relative path reference for file display

--- a/src/factories/fromPath.node.ts
+++ b/src/factories/fromPath.node.ts
@@ -1,0 +1,55 @@
+/*!
+This file is part of CycloneDX JavaScript Library.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) OWASP Foundation. All Rights Reserved.
+*/
+
+/**
+ * Node-specifics.
+ */
+
+import {readFileSync} from "fs";
+
+import {getMimeForTextFile} from "../_helpers/mime";
+import {AttachmentEncoding} from "../enums/attachmentEncoding";
+import {Attachment} from "../models/attachment";
+
+
+
+/**
+ * Node-specific AttachmentFactory.
+ */
+export class AttachmentFactory {
+
+  public fromFile(file: string, contentType: string): Attachment {
+    return new Attachment(
+          // may throw if `readFileSync()` fails
+          readFileSync(file).toString('base64'),
+          {
+            contentType,
+            encoding: AttachmentEncoding.Base64
+          })
+  }
+
+  public fromTextFile(file: string): Attachment | undefined {
+    const contentType = getMimeForTextFile(file)
+    if (contentType === undefined) {
+      return undefined
+    }
+    return this.fromFile(file, contentType)
+  }
+
+}

--- a/src/factories/fromPath.node.ts
+++ b/src/factories/fromPath.node.ts
@@ -23,7 +23,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 
 import {readFileSync} from "fs";
 
-import {getMimeForTextFile, MimeType} from "../_helpers/mime";
+import {getMimeForTextFile, type MimeType} from "../_helpers/mime";
 import {AttachmentEncoding} from "../enums/attachmentEncoding";
 import {Attachment} from "../models/attachment";
 

--- a/src/factories/fromPath.node.ts
+++ b/src/factories/fromPath.node.ts
@@ -23,9 +23,10 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 
 import {readFileSync} from "fs";
 
-import {getMimeTypeForTextFile, type MimeType} from "../_helpers/mime";
+import {getMimeTypeForTextFile} from "../_helpers/mime";
 import {AttachmentEncoding} from "../enums/attachmentEncoding";
 import {Attachment} from "../models/attachment";
+import type {MimeType} from "../types/mimeType";
 
 
 
@@ -35,15 +36,14 @@ import {Attachment} from "../models/attachment";
 export class AttachmentFactory {
 
   /**
-   * Return an attachment on success.
-   * Throws error, if content could not be fetched.
+   * Throws error, if file content could not be read.
    *
-   * @returns {@link NamedLicense} on success
+   * Content will be base64 encoded.
    */
-  public fromFile(file: string, contentType: MimeType): Attachment {
+  public fromFile(file: string, contentType: MimeType | undefined = undefined): Attachment {
     return new Attachment(
           // may throw if `readFileSync()` fails
-          readFileSync(file).toString('base64'),
+          readFileSync(file, {encoding: 'base64'}),
           {
             contentType,
             encoding: AttachmentEncoding.Base64
@@ -51,10 +51,11 @@ export class AttachmentFactory {
   }
 
   /**
-   * Return an attachment on success, returns undefined if it appears to bes no known text file.
+   * Return an attachment on success.
+   * Returns undefined if it appears to be no known text file.
    * Throws error, if content could not be fetched.
    *
-   * @returns {@link Attachment} on success
+   * Tries to guess the file's mime-type.
    */
   public fromTextFile(file: string): Attachment | undefined {
     const contentType = getMimeTypeForTextFile(file)

--- a/src/factories/fromPath.node.ts
+++ b/src/factories/fromPath.node.ts
@@ -23,7 +23,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 
 import {readFileSync} from "fs";
 
-import {getMimeForTextFile, type MimeType} from "../_helpers/mime";
+import {getMimeTypeForTextFile, type MimeType} from "../_helpers/mime";
 import {AttachmentEncoding} from "../enums/attachmentEncoding";
 import {Attachment} from "../models/attachment";
 
@@ -45,7 +45,7 @@ export class AttachmentFactory {
   }
 
   public fromTextFile(file: string): Attachment | undefined {
-    const contentType = getMimeForTextFile(file)
+    const contentType = getMimeTypeForTextFile(file)
     if (contentType === undefined) {
       return undefined
     }

--- a/src/factories/fromPath.node.ts
+++ b/src/factories/fromPath.node.ts
@@ -23,7 +23,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 
 import {readFileSync} from "fs";
 
-import {getMimeForTextFile} from "../_helpers/mime";
+import {getMimeForTextFile, MimeType} from "../_helpers/mime";
 import {AttachmentEncoding} from "../enums/attachmentEncoding";
 import {Attachment} from "../models/attachment";
 
@@ -34,7 +34,7 @@ import {Attachment} from "../models/attachment";
  */
 export class AttachmentFactory {
 
-  public fromFile(file: string, contentType: string): Attachment {
+  public fromFile(file: string, contentType: MimeType): Attachment {
     return new Attachment(
           // may throw if `readFileSync()` fails
           readFileSync(file).toString('base64'),

--- a/src/factories/fromPath.node.ts
+++ b/src/factories/fromPath.node.ts
@@ -34,6 +34,12 @@ import {Attachment} from "../models/attachment";
  */
 export class AttachmentFactory {
 
+  /**
+   * Return an attachment on success.
+   * Throws error, if content could not be fetched.
+   *
+   * @returns {@link NamedLicense} on success
+   */
   public fromFile(file: string, contentType: MimeType): Attachment {
     return new Attachment(
           // may throw if `readFileSync()` fails
@@ -44,6 +50,12 @@ export class AttachmentFactory {
           })
   }
 
+  /**
+   * Return an attachment on success, returns undefined if it appears to bes no known text file.
+   * Throws error, if content could not be fetched.
+   *
+   * @returns {@link Attachment} on success
+   */
   public fromTextFile(file: string): Attachment | undefined {
     const contentType = getMimeTypeForTextFile(file)
     if (contentType === undefined) {

--- a/src/factories/index.node.ts
+++ b/src/factories/index.node.ts
@@ -22,5 +22,6 @@ export * from './index.common'
 // region node-specifics
 
 export * as FromNodePackageJson from './fromNodePackageJson.node'
+export * as FromPath from './fromPath.node'
 
 // endregion node-specifics


### PR DESCRIPTION

fixes #1162

> [!NOTE]
> on hold - see <https://github.com/CycloneDX/cyclonedx-javascript-library/pull/1158#issuecomment-2448604457>

----


refactored the evidence collection from our sister project <https://github.com/CycloneDX/cyclonedx-webpack-plugin>.

----

original: 
https://github.com/CycloneDX/cyclonedx-webpack-plugin/blob/72700f06d00eac79fa3b91fe838bd78c583346a2/src/extractor.ts#L133-L173

the original file is under Apache-2.0 license, and rights owner is OWASP.
All the same applies to this very project. Therefore, no legal issues exist -> we are free to copy/paste/modify the code without the slightest concerns.


----

need to see if there are additional requirements from https://github.com/CycloneDX/cyclonedx-node-yarn/pull/193 