### PR TITLE
feat: tools as `Component`s & `Service`s

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,11 +7,14 @@ All notable changes to this project will be documented in this file.
 <!-- add unreleased items here -->
 
 * BREAKING changes
-    * ...
+    * Property `Models.Bom.tools` is an instance of `Models.Tools` now ([#1152] via [#1163])  
+      Before, it was an instance of `Models.ToolRepository`.
 * Added
-    * ...
+    * Class `Models.Tools` ([#1152] via [#1163])
+    * Static function `Models.Tool.fromComponent()` (via [#1163])
+    * Static function `Models.Tool.fromService()` (via [#1163])
 * Changed
-    * ...
+    * Serializers and `Bom`-Normalizers will take changed `Models.Bom.tools` into account ([#1152] via [#1163])
 
 [#1152]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/1152
 [#1163]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/1163

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,16 @@ All notable changes to this project will be documented in this file.
 
 <!-- add unreleased items here -->
 
+* BREAKING changes
+    * ...
+* Added
+    * ...
+* Changed
+    * ...
+
+[#1152]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/1152
+[#1163]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/1163
+
 ## 6.12.0 -- 2024-11-12
 
 * Added

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -17,7 +17,6 @@ All notable changes to this project will be documented in this file.
 * Changed
     * Serializers and `Bom`-Normalizers will take changed `Models.Bom.tools` into account ([#1152] via [#1163])
 
-
 [#1152]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/1152
 [#1163]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/1163
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,8 +13,10 @@ All notable changes to this project will be documented in this file.
     * Class `Models.Tools` ([#1152] via [#1163])
     * Static function `Models.Tool.fromComponent()` (via [#1163])
     * Static function `Models.Tool.fromService()` (via [#1163])
+    * New data models and serialization/normalization for `Models.Tools` ([#1152] via [#1163])
 * Changed
     * Serializers and `Bom`-Normalizers will take changed `Models.Bom.tools` into account ([#1152] via [#1163])
+
 
 [#1152]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/1152
 [#1163]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/1163

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,15 +7,15 @@ All notable changes to this project will be documented in this file.
 <!-- add unreleased items here -->
 
 * BREAKING changes
-    * Property `Models.Bom.tools` is an instance of `Models.Tools` now ([#1152] via [#1163])  
-      Before, it was an instance of `Models.ToolRepository`.
+  * Property `Models.Bom.tools` is an instance of `Models.Tools` now ([#1152] via [#1163])  
+    Before, it was an instance of `Models.ToolRepository`.
 * Added
-    * Class `Models.Tools` ([#1152] via [#1163])
-    * Static function `Models.Tool.fromComponent()` (via [#1163])
-    * Static function `Models.Tool.fromService()` (via [#1163])
-    * New serialization/normalization for `Models.Tools` ([#1152] via [#1163])
+  * Class `Models.Tools` ([#1152] via [#1163])
+  * Static function `Models.Tool.fromComponent()` (via [#1163])
+  * Static function `Models.Tool.fromService()` (via [#1163])
+  * New serialization/normalization for `Models.Tools` ([#1152] via [#1163])
 * Changed
-    * Serializers and `Bom`-Normalizers will take changed `Models.Bom.tools` into account ([#1152] via [#1163])
+  * Serializers and `Bom`-Normalizers will take changed `Models.Bom.tools` into account ([#1152] via [#1163])
 
 [#1152]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/1152
 [#1163]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/1163

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
     * Class `Models.Tools` ([#1152] via [#1163])
     * Static function `Models.Tool.fromComponent()` (via [#1163])
     * Static function `Models.Tool.fromService()` (via [#1163])
-    * New data models and serialization/normalization for `Models.Tools` ([#1152] via [#1163])
+    * New serialization/normalization for `Models.Tools` ([#1152] via [#1163])
 * Changed
     * Serializers and `Bom`-Normalizers will take changed `Models.Bom.tools` into account ([#1152] via [#1163])
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,9 +10,9 @@ All notable changes to this project will be documented in this file.
   * Property `Models.Bom.tools` is an instance of `Models.Tools` now ([#1152] via [#1163])  
     Before, it was an instance of `Models.ToolRepository`.
 * Added
-  * Class `Models.Tools` ([#1152] via [#1163])
   * Static function `Models.Tool.fromComponent()` (via [#1163])
   * Static function `Models.Tool.fromService()` (via [#1163])
+  * New class `Models.Tools` ([#1152] via [#1163])
   * New serialization/normalization for `Models.Tools` ([#1152] via [#1163])
 * Changed
   * Serializers and `Bom`-Normalizers will take changed `Models.Bom.tools` into account ([#1152] via [#1163])

--- a/src/_helpers/iterable.ts
+++ b/src/_helpers/iterable.ts
@@ -17,7 +17,7 @@ SPDX-License-Identifier: Apache-2.0
 Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
-export function * chainI<T = any> (...iterables: Array<Iterable<T>>): Generator<T> {
+export function * chainI<T> (...iterables: Array<Iterable<T>>): Generator<T> {
   for (const iterable of iterables) {
     for (const item of iterable) {
       yield item

--- a/src/_helpers/iterable.ts
+++ b/src/_helpers/iterable.ts
@@ -1,0 +1,26 @@
+/*!
+This file is part of CycloneDX JavaScript Library.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) OWASP Foundation. All Rights Reserved.
+*/
+
+export function * chainI<T = any> (...iterables: Array<Iterable<T>>): Generator<T> {
+  for (const iterable of iterables) {
+    for (const item of iterable) {
+      yield item
+    }
+  }
+}

--- a/src/models/metadata.ts
+++ b/src/models/metadata.ts
@@ -23,7 +23,7 @@ import { LifecycleRepository } from './lifecycle'
 import { OrganizationalContactRepository } from './organizationalContact'
 import type { OrganizationalEntity } from './organizationalEntity'
 import { PropertyRepository } from './property'
-import { ToolRepository } from './tool'
+import { Tools } from './tool'
 
 export interface OptionalMetadataProperties {
   timestamp?: Metadata['timestamp']
@@ -40,7 +40,7 @@ export interface OptionalMetadataProperties {
 export class Metadata {
   timestamp?: Date
   lifecycles: LifecycleRepository
-  tools: ToolRepository
+  tools: Tools
   authors: OrganizationalContactRepository
   component?: Component
   manufacture?: OrganizationalEntity
@@ -51,7 +51,7 @@ export class Metadata {
   constructor (op: OptionalMetadataProperties = {}) {
     this.timestamp = op.timestamp
     this.lifecycles = op.lifecycles ?? new LifecycleRepository()
-    this.tools = op.tools ?? new ToolRepository()
+    this.tools = op.tools ?? new Tools()
     this.authors = op.authors ?? new OrganizationalContactRepository()
     this.component = op.component
     this.manufacture = op.manufacture

--- a/src/models/tool.ts
+++ b/src/models/tool.ts
@@ -19,9 +19,12 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 
 import type { Comparable } from '../_helpers/sortable'
 import { SortableComparables } from '../_helpers/sortable'
-import {type Component, ComponentRepository} from "./component";
+import type { Component } from "./component";
+import { ComponentRepository} from "./component";
 import { ExternalReferenceRepository } from './externalReference'
 import { HashDictionary } from './hash'
+import type { Service } from "./service";
+import { ServiceRepository } from "./service";
 
 export interface OptionalToolProperties {
   vendor?: Tool['vendor']
@@ -64,6 +67,15 @@ export class Tool implements Comparable<Tool> {
       externalReferences: component.externalReferences
     })
   }
+
+  static fromService(service: Service): Tool {
+    return new Tool({
+      vendor: service.group,
+      name: service.name,
+      version: service.version,
+      externalReferences: service.externalReferences
+    })
+  }
 }
 
 export class ToolRepository extends SortableComparables<Tool> {
@@ -71,25 +83,25 @@ export class ToolRepository extends SortableComparables<Tool> {
 
 
 export interface OptionalToolsProperties {
-  components?: ComponentRepository
-  // TODO: services
-  tools?: ToolRepository
+  components?: Tools['components']
+  services?: Tools['services']
+  tools?: Tools['tools']
 }
 
 export class Tools {
   components: ComponentRepository
-  // TODO: services
+  services: ServiceRepository
   tools: ToolRepository
 
   constructor(op: OptionalToolsProperties = {}) {
     this.components = op.components ?? new ComponentRepository()
-    // TODO: this.services
+    this.services = op.services ?? new ServiceRepository()
     this.tools = op.tools ?? new ToolRepository()
   }
 
   get size(): number {
     return this.components.size
-      // TODO: this.services
+      + this.services.size
       + this.tools.size
   }
 }

--- a/src/models/tool.ts
+++ b/src/models/tool.ts
@@ -19,9 +19,9 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 
 import type { Comparable } from '../_helpers/sortable'
 import { SortableComparables } from '../_helpers/sortable'
+import {type Component, ComponentRepository} from "./component";
 import { ExternalReferenceRepository } from './externalReference'
 import { HashDictionary } from './hash'
-import {type Component, ComponentRepository} from "./component";
 
 export interface OptionalToolProperties {
   vendor?: Tool['vendor']

--- a/src/models/tool.ts
+++ b/src/models/tool.ts
@@ -72,6 +72,7 @@ export class ToolRepository extends SortableComparables<Tool> {
 
 export interface OptionalToolsProperties {
   components?: ComponentRepository
+  // TODO: services
   tools?: ToolRepository
 }
 

--- a/src/models/tool.ts
+++ b/src/models/tool.ts
@@ -21,6 +21,7 @@ import type { Comparable } from '../_helpers/sortable'
 import { SortableComparables } from '../_helpers/sortable'
 import { ExternalReferenceRepository } from './externalReference'
 import { HashDictionary } from './hash'
+import {type Component, ComponentRepository} from "./component";
 
 export interface OptionalToolProperties {
   vendor?: Tool['vendor']
@@ -53,7 +54,41 @@ export class Tool implements Comparable<Tool> {
       (this.version ?? '').localeCompare(other.version ?? '')
     /* eslint-enable @typescript-eslint/strict-boolean-expressions */
   }
+
+  static fromComponent(component: Component): Tool {
+    return new Tool({
+      vendor: component.group,
+      name: component.name,
+      version: component.version,
+      hashes: component.hashes,
+      externalReferences: component.externalReferences
+    })
+  }
 }
 
 export class ToolRepository extends SortableComparables<Tool> {
+}
+
+
+export interface OptionalToolsProperties {
+  components?: ComponentRepository
+  tools?: ToolRepository
+}
+
+export class Tools {
+  components: ComponentRepository
+  // TODO: services
+  tools: ToolRepository
+
+  constructor(op: OptionalToolsProperties = {}) {
+    this.components = op.components ?? new ComponentRepository()
+    // TODO: this.services
+    this.tools = op.tools ?? new ToolRepository()
+  }
+
+  get size(): number {
+    return this.components.size
+      // TODO: this.services
+      + this.tools.size
+  }
 }

--- a/src/models/vulnerability/vulnerability.ts
+++ b/src/models/vulnerability/vulnerability.ts
@@ -22,7 +22,7 @@ import { SortableComparables } from '../../_helpers/sortable'
 import { CweRepository } from '../../types/cwe'
 import { BomRef } from '../bomRef'
 import { PropertyRepository } from '../property'
-import { ToolRepository } from '../tool'
+import { Tools } from '../tool'
 import { AdvisoryRepository } from './advisory'
 import { AffectRepository } from './affect'
 import type { Analysis } from './analysis'
@@ -68,7 +68,7 @@ export class Vulnerability implements Comparable<Vulnerability> {
   published?: Date
   updated?: Date
   credits?: Credits
-  tools: ToolRepository
+  tools: Tools
   analysis?: Analysis
   affects: AffectRepository
   properties: PropertyRepository
@@ -88,7 +88,7 @@ export class Vulnerability implements Comparable<Vulnerability> {
     this.published = op.published
     this.updated = op.updated
     this.credits = op.credits
-    this.tools = op.tools ?? new ToolRepository()
+    this.tools = op.tools ?? new Tools()
     this.analysis = op.analysis
     this.affects = op.affects ?? new AffectRepository()
     this.properties = op.properties ?? new PropertyRepository()

--- a/src/serialize/json/normalize.ts
+++ b/src/serialize/json/normalize.ts
@@ -297,13 +297,13 @@ export class ToolsNormalizer extends BaseJsonNormalizer<Models.Tools> {
       return this._factory.makeForTool().normalizeIterable(
         new ToolRepository(chainI<Models.Tool>(
           Array.from(data.components, Tool.fromComponent),
-          // TODO services
+          Array.from(data.services, Tool.fromService),
           data.tools,
         )), options)
     }
     return {
-      components: this._factory.makeForComponent().normalizeIterable(data.components, options)
-      // TODO services
+      components: this._factory.makeForComponent().normalizeIterable(data.components, options),
+      services: this._factory.makeForService().normalizeIterable(data.services, options)
     }
   }
 }

--- a/src/serialize/json/normalize.ts
+++ b/src/serialize/json/normalize.ts
@@ -17,15 +17,16 @@ SPDX-License-Identifier: Apache-2.0
 Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
+import { chainI } from "../../_helpers/iterable";
 import { isNotUndefined } from '../../_helpers/notUndefined'
 import type { SortableIterable } from '../../_helpers/sortable'
 import type { Stringable } from '../../_helpers/stringable'
 import { treeIteratorSymbol } from '../../_helpers/tree'
 import { escapeUri } from '../../_helpers/uri'
 import type * as Models from '../../models'
-import { ToolRepository } from '../../models/tool'
 import { LicenseExpression, NamedLicense, SpdxLicense } from '../../models/license'
 import { NamedLifecycle } from '../../models/lifecycle'
+import { Tool, ToolRepository } from '../../models/tool'
 import { AffectedSingleVersion, AffectedVersionRange } from '../../models/vulnerability/affect'
 import { isSupportedSpdxId } from '../../spdx'
 import type { _SpecProtocol as Spec } from '../../spec/_protocol'
@@ -33,8 +34,6 @@ import { Version as SpecVersion } from '../../spec/enums'
 import type { NormalizerOptions } from '../types'
 import type { Normalized } from './types'
 import { JsonSchema } from './types'
-import { chainI} from "../../_helpers/iterable";
-import {Tool} from "../../models";
 
 export class Factory {
   readonly #spec: Spec

--- a/src/serialize/json/normalize.ts
+++ b/src/serialize/json/normalize.ts
@@ -294,7 +294,7 @@ export class ToolNormalizer extends BaseJsonNormalizer<Models.Tool> {
 
 export class ToolsNormalizer extends BaseJsonNormalizer<Models.Tools> {
   normalize(data: Models.Tools, options: NormalizerOptions): Normalized.ToolsType {
-    if (data.tools.size > 0) {
+    if (data.tools.size > 0 || !this._factory.spec.supportsToolsComponentsServices) {
       return this._factory.makeForTool().normalizeIterable(
         new ToolRepository(chainI<Models.Tool>(
           Array.from(data.components, Tool.fromComponent),

--- a/src/serialize/json/types.ts
+++ b/src/serialize/json/types.ts
@@ -90,7 +90,7 @@ export namespace Normalized {
   export interface Metadata {
     timestamp?: JsonSchema.DateTime
     lifecycles?: Lifecycle[]
-    tools?: Tool[]
+    tools?: ToolsType
     authors?: OrganizationalContact[]
     component?: Component
     manufacture?: OrganizationalEntity
@@ -117,6 +117,14 @@ export namespace Normalized {
     hashes?: Hash[]
     externalReferences?: ExternalReference[]
   }
+
+  /** since CDX 1.5 */
+  export interface Tools {
+    components: Component[]
+    // TODO: services
+  }
+
+  export type ToolsType = Tools | Tool[]
 
   export interface OrganizationalContact {
     name?: string
@@ -257,7 +265,7 @@ export namespace Normalized {
     published?: JsonSchema.DateTime
     updated?: JsonSchema.DateTime
     credits?: Vulnerability.Credits
-    tools?: Tool[]
+    tools?: ToolsType
     analysis?: Vulnerability.Analysis
     affects?: Vulnerability.Affect[]
     properties?: Property[]

--- a/src/serialize/json/types.ts
+++ b/src/serialize/json/types.ts
@@ -121,7 +121,7 @@ export namespace Normalized {
   /** since CDX 1.5 */
   export interface Tools {
     components: Component[]
-    // TODO: services
+    services: Service[]
   }
 
   export type ToolsType = Tools | Tool[]

--- a/src/serialize/xml/normalize.ts
+++ b/src/serialize/xml/normalize.ts
@@ -17,12 +17,14 @@ SPDX-License-Identifier: Apache-2.0
 Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
+import { chainI } from "../../_helpers/iterable";
 import { isNotUndefined } from '../../_helpers/notUndefined'
 import type { SortableIterable } from '../../_helpers/sortable'
 import type { Stringable } from '../../_helpers/stringable'
 import { treeIteratorSymbol } from '../../_helpers/tree'
 import { escapeUri } from '../../_helpers/uri'
 import type * as Models from '../../models'
+import { Tool, ToolRepository } from "../../models";
 import { LicenseExpression, NamedLicense, SpdxLicense } from '../../models/license'
 import { NamedLifecycle } from '../../models/lifecycle'
 import { AffectedSingleVersion, AffectedVersionRange } from '../../models/vulnerability/affect'
@@ -33,8 +35,6 @@ import type { NormalizerOptions } from '../types'
 import { normalizedString, token} from './_xsd'
 import type { SimpleXml } from './types'
 import { XmlSchema } from './types'
-import {Tool, ToolRepository} from "../../models";
-import {chainI} from "../../_helpers/iterable";
 
 export class Factory {
   readonly #spec: Spec
@@ -376,7 +376,7 @@ export class ToolsNormalizer extends BaseXmlNormalizer<Models.Tools> {
     let children: SimpleXml.Element[]
     if (data.tools.size > 0 || !this._factory.spec.supportsToolsComponentsServices) {
       children = this._factory.makeForTool().normalizeIterable(
-        new ToolRepository(chainI<Models.Tool>(
+        new ToolRepository(chainI(
           Array.from(data.components, Tool.fromComponent),
           // TODO services
           data.tools,

--- a/src/serialize/xml/normalize.ts
+++ b/src/serialize/xml/normalize.ts
@@ -378,7 +378,7 @@ export class ToolsNormalizer extends BaseXmlNormalizer<Models.Tools> {
       children = this._factory.makeForTool().normalizeIterable(
         new ToolRepository(chainI(
           Array.from(data.components, Tool.fromComponent),
-          // TODO services
+          Array.from(data.services, Tool.fromService),
           data.tools,
         )), options, 'tool')
     } else {
@@ -390,7 +390,13 @@ export class ToolsNormalizer extends BaseXmlNormalizer<Models.Tools> {
           children: this._factory.makeForComponent().normalizeIterable(data.components, options, 'component')
         })
       }
-      // TODO data.services
+      if (data.components.size > 0) {
+        children.push({
+          type: 'element',
+          name: 'services',
+          children: this._factory.makeForService().normalizeIterable(data.services, options, 'service')
+        })
+      }
     }
     return {
       type: 'element',

--- a/src/serialize/xml/normalize.ts
+++ b/src/serialize/xml/normalize.ts
@@ -373,7 +373,7 @@ export class ToolNormalizer extends BaseXmlNormalizer<Models.Tool> {
 
 export class ToolsNormalizer extends BaseXmlNormalizer<Models.Tools> {
   normalize (data: Models.Tools, options: NormalizerOptions, elementName: string): SimpleXml.Element {
-    let children: SimpleXml.Element[]
+    let children: SimpleXml.Element[] = []
     if (data.tools.size > 0 || !this._factory.spec.supportsToolsComponentsServices) {
       children = this._factory.makeForTool().normalizeIterable(
         new ToolRepository(chainI(
@@ -382,7 +382,6 @@ export class ToolsNormalizer extends BaseXmlNormalizer<Models.Tools> {
           data.tools,
         )), options, 'tool')
     } else {
-      children = []
       if (data.components.size > 0) {
         children.push({
           type: 'element',

--- a/src/serialize/xml/normalize.ts
+++ b/src/serialize/xml/normalize.ts
@@ -256,7 +256,7 @@ export class MetadataNormalizer extends BaseXmlNormalizer<Models.Metadata> {
         }
       : undefined
     const tools: SimpleXml.Element | undefined = data.tools.size > 0
-      ? this._factory.makeForTools().normalize(data.tools, options)
+      ? this._factory.makeForTools().normalize(data.tools, options, 'tools')
       : undefined
     const authors: SimpleXml.Element | undefined = data.authors.size > 0
       ? {
@@ -374,7 +374,7 @@ export class ToolNormalizer extends BaseXmlNormalizer<Models.Tool> {
 export class ToolsNormalizer extends BaseXmlNormalizer<Models.Tools> {
   normalize (data: Models.Tools, options: NormalizerOptions, elementName: string): SimpleXml.Element {
     let children: SimpleXml.Element[]
-    if (data.tools.size > 0) {
+    if (data.tools.size > 0 || !this._factory.spec.supportsToolsComponentsServices) {
       children = this._factory.makeForTool().normalizeIterable(
         new ToolRepository(chainI<Models.Tool>(
           Array.from(data.components, Tool.fromComponent),
@@ -966,11 +966,7 @@ export class VulnerabilityNormalizer extends BaseXmlNormalizer<Models.Vulnerabil
         }
       : undefined
     const tools: SimpleXml.Element | undefined = data.tools.size > 0
-      ? {
-          type: 'element',
-          name: 'tools',
-          children: this._factory.makeForTools().normalize(data.tools, options)
-        }
+      ? this._factory.makeForTools().normalize(data.tools, options, 'tools')
       : undefined
     const affects: SimpleXml.Element | undefined = data.affects.size > 0
       ? {

--- a/src/spec/_protocol.ts
+++ b/src/spec/_protocol.ts
@@ -48,6 +48,7 @@ export interface _SpecProtocol {
   supportsExternalReferenceHashes: boolean
   supportsLicenseAcknowledgement: boolean
   supportsServices:boolean
+  supportsToolsComponentsServices:boolean
 }
 
 /**
@@ -77,6 +78,7 @@ export class _Spec implements _SpecProtocol {
   readonly #supportsExternalReferenceHashes: boolean
   readonly #supportsLicenseAcknowledgement: boolean
   readonly #supportsServices: boolean
+  readonly #supportsToolsComponentsServices:boolean
 
   /* eslint-disable-next-line @typescript-eslint/max-params -- architectural decision */
   constructor (
@@ -99,6 +101,8 @@ export class _Spec implements _SpecProtocol {
     supportsExternalReferenceHashes: boolean,
     supportsLicenseAcknowledgement: boolean,
     supportsServices:boolean
+    supportsLicenseAcknowledgement: boolean,
+    supportsToolsComponentsServices:boolean
   ) {
     this.#version = version
     this.#formats = new Set(formats)
@@ -119,6 +123,7 @@ export class _Spec implements _SpecProtocol {
     this.#supportsExternalReferenceHashes = supportsExternalReferenceHashes
     this.#supportsLicenseAcknowledgement = supportsLicenseAcknowledgement
     this.#supportsServices = supportsServices
+    this.#supportsToolsComponentsServices=supportsToolsComponentsServices
   }
 
   get version (): Version {
@@ -202,5 +207,9 @@ export class _Spec implements _SpecProtocol {
 
   get supportsServices (): boolean {
     return this.#supportsServices
+  }
+
+  get supportsToolsComponentsServices(): boolean {
+    return this.#supportsToolsComponentsServices
   }
 }

--- a/src/spec/_protocol.ts
+++ b/src/spec/_protocol.ts
@@ -47,8 +47,8 @@ export interface _SpecProtocol {
   supportsMetadataProperties: boolean
   supportsExternalReferenceHashes: boolean
   supportsLicenseAcknowledgement: boolean
-  supportsServices:boolean
-  supportsToolsComponentsServices:boolean
+  supportsServices: boolean
+  supportsToolsComponentsServices: boolean
 }
 
 /**
@@ -78,7 +78,7 @@ export class _Spec implements _SpecProtocol {
   readonly #supportsExternalReferenceHashes: boolean
   readonly #supportsLicenseAcknowledgement: boolean
   readonly #supportsServices: boolean
-  readonly #supportsToolsComponentsServices:boolean
+  readonly #supportsToolsComponentsServices: boolean
 
   /* eslint-disable-next-line @typescript-eslint/max-params -- architectural decision */
   constructor (
@@ -100,9 +100,8 @@ export class _Spec implements _SpecProtocol {
     supportsMetadataProperties: boolean,
     supportsExternalReferenceHashes: boolean,
     supportsLicenseAcknowledgement: boolean,
-    supportsServices:boolean
-    supportsLicenseAcknowledgement: boolean,
-    supportsToolsComponentsServices:boolean
+    supportsServices: boolean,
+    supportsToolsComponentsServices: boolean
   ) {
     this.#version = version
     this.#formats = new Set(formats)
@@ -123,7 +122,7 @@ export class _Spec implements _SpecProtocol {
     this.#supportsExternalReferenceHashes = supportsExternalReferenceHashes
     this.#supportsLicenseAcknowledgement = supportsLicenseAcknowledgement
     this.#supportsServices = supportsServices
-    this.#supportsToolsComponentsServices=supportsToolsComponentsServices
+    this.#supportsToolsComponentsServices = supportsToolsComponentsServices
   }
 
   get version (): Version {

--- a/src/spec/consts.ts
+++ b/src/spec/consts.ts
@@ -86,7 +86,8 @@ export const Spec1dot2: Readonly<_SpecProtocol> = Object.freeze(new _Spec(
   false,
   false,
   false,
-  true
+  true,
+  false
 ))
 
 /** Specification v1.3 */
@@ -150,7 +151,8 @@ export const Spec1dot3: Readonly<_SpecProtocol> = Object.freeze(new _Spec(
   true,
   true,
   false,
-  true
+  true,
+  false
 ))
 
 /** Specification v1.4 */
@@ -221,7 +223,8 @@ export const Spec1dot4: Readonly<_SpecProtocol> = Object.freeze(new _Spec(
   true,
   true,
   false,
-  true
+  true,
+  false
 ))
 
 /** Specification v1.5 */
@@ -321,6 +324,7 @@ export const Spec1dot5: Readonly<_SpecProtocol> = Object.freeze(new _Spec(
   true,
   true,
   false,
+  true,
   true
 ))
 
@@ -420,6 +424,7 @@ export const Spec1dot6: Readonly<_SpecProtocol> = Object.freeze(new _Spec(
     VulnerabilityRatingMethod.SSVC,
     VulnerabilityRatingMethod.Other
   ],
+  true,
   true,
   true,
   true,

--- a/tests/_data/models.js
+++ b/tests/_data/models.js
@@ -62,7 +62,17 @@ module.exports.createComplexStructure = function () {
             })
         ]),
         services: new Models.ServiceRepository([
-          new Models.Service('sbom-generator-service')
+          new Models.Service('sbom-generator-service', {
+            group: 'Service service group',
+            version: '1',
+            externalReferences: new Models.ExternalReferenceRepository([
+              new Models.ExternalReference(
+                'https://example.com/sbom-generator-service/',
+                Enums.ExternalReferenceType.Website,
+                { comment: 'the service that made this' }
+              )
+            ])
+          })
         ])
       }),
       authors: new Models.OrganizationalContactRepository([
@@ -313,7 +323,6 @@ module.exports.createComplexStructure = function () {
     service.bomRef.value = 'some-service'
     service.provider = new Models.OrganizationalEntity({ name: 'Service Provider' })
     service.group = 'acme'
-    service.version = '1.2+service-version'
     service.description = 'this is a test service'
     service.externalReferences.add(new Models.ExternalReference(
       'https://localhost/service/docs',
@@ -597,5 +606,67 @@ module.exports.createComplexStructure = function () {
       ])
     }))
 
+  return bom
+}
+
+
+/**
+ * @returns {Models.Bom}
+ */
+module.exports.createAllTools = function () {
+  const bomSerialNumberRaw = '8fd9e244-73b6-4cd3-ab3a-a0fefdee5c9e'
+  const bom = new Models.Bom({
+    version: 7,
+    serialNumber: `urn:uuid:${bomSerialNumberRaw}`,
+  })
+  bom.metadata.tools.components.push(
+    new Models.Component(
+      Enums.ComponentType.Application,
+      'Component tool name', {
+        group: 'Component tool group',
+        version: '0.8.15',
+        hashes: new Models.HashDictionary([
+          [Enums.HashAlgorithm.MD5, '974e5cc07da6e4536bffd935fd4ddc61'],
+          [Enums.HashAlgorithm['SHA-1'], '2aae6c35c94fcfb415dbe95f408b9ce91ee846ed']
+        ])
+      }))
+  bom.metadata.tools.services.push(
+    new Models.Service('sbom-generator-service', {
+      group: 'Service tool group',
+      version: '1',
+      externalReferences: new Models.ExternalReferenceRepository([
+        new Models.ExternalReference(
+          'https://example.com/sbom-generator-service/',
+          Enums.ExternalReferenceType.Website,
+          { comment: 'the service that made this' }
+        )
+      ])
+    })
+  )
+  bom.metadata.tools.tools.push(
+    new Models.Tool({
+      vendor: 'Tool tool vendor',
+      name: 'Tool tool name',
+      version: '0.8.15',
+      hashes: new Models.HashDictionary([
+        [Enums.HashAlgorithm.MD5, 'f32a26e2a3a8aa338cd77b6e1263c535'],
+        [Enums.HashAlgorithm['SHA-1'], '829c3804401b0727f70f73d4415e162400cbe57b']
+      ])
+    })
+  )
+  bom.metadata.tools.tools.push(
+    new Models.Tool({
+      vendor: 'Tool tool vendor',
+      name: 'Tool other tool',
+      version: '', // empty string, not undefined
+      externalReferences: new Models.ExternalReferenceRepository([
+        new Models.ExternalReference(
+          'https://cyclonedx.org/tool-center/',
+          Enums.ExternalReferenceType.Website,
+          { comment: 'the tools that made this' }
+        )
+      ])
+    })
+  )
   return bom
 }

--- a/tests/_data/models.js
+++ b/tests/_data/models.js
@@ -35,29 +35,33 @@ module.exports.createComplexStructure = function () {
         Enums.LifecyclePhase.Design,
         new Models.NamedLifecycle('testing', { description: 'my testing stage' })
       ]),
-      tools: new Models.ToolRepository([
-        new Models.Tool({
-          vendor: 'tool vendor',
-          name: 'tool name',
-          version: '0.8.15',
-          hashes: new Models.HashDictionary([
-            [Enums.HashAlgorithm.MD5, 'f32a26e2a3a8aa338cd77b6e1263c535'],
-            [Enums.HashAlgorithm['SHA-1'], '829c3804401b0727f70f73d4415e162400cbe57b']
-          ])
-        }),
-        new Models.Tool({
-          vendor: 'tool vendor',
-          name: 'other tool',
-          version: '', // empty string, not undefined
-          externalReferences: new Models.ExternalReferenceRepository([
-            new Models.ExternalReference(
-              'https://cyclonedx.org/tool-center/',
-              Enums.ExternalReferenceType.Website,
-              { comment: 'the tools that made this' }
-            )
-          ])
-        })
-      ]),
+      tools: new Models.Tools({
+        components: new Models.ComponentRepository([
+          new Models.Component(
+            Enums.ComponentType.Application,
+            'tool name', {
+              group: 'tool group',
+              version: '0.8.15',
+              hashes: new Models.HashDictionary([
+                [Enums.HashAlgorithm.MD5, 'f32a26e2a3a8aa338cd77b6e1263c535'],
+                [Enums.HashAlgorithm['SHA-1'], '829c3804401b0727f70f73d4415e162400cbe57b']
+              ])
+            }),
+          new Models.Component(
+            Enums.ComponentType.Library,
+            'tool name', {
+              group: 'tool group',
+              version: '', // empty string, not undefined
+              externalReferences: new Models.ExternalReferenceRepository([
+                new Models.ExternalReference(
+                  'https://cyclonedx.org/tool-center/',
+                  Enums.ExternalReferenceType.Website,
+                  { comment: 'the tools that made this' }
+                )
+              ])
+            })
+        ])
+      }),
       authors: new Models.OrganizationalContactRepository([
         new Models.OrganizationalContact({ name: 'John "the-co-author" Doe' }),
         new Models.OrganizationalContact({
@@ -452,12 +456,14 @@ module.exports.createComplexStructure = function () {
           new Models.OrganizationalContact({ name: 'John "pentester" Doe' })
         ])
       }),
-      tools: new Models.ToolRepository([
-        new Models.Tool({
-          vendor: 'v the vendor',
-          name: 'tool name'
-        })
-      ]),
+      tools: new Models.Tools({
+        tools: new Models.ToolRepository([
+          new Models.Tool({
+            vendor: 'v the vendor',
+            name: 'tool name'
+          })
+        ])
+      }),
       analysis: new Models.Vulnerability.Analysis({
         state: Enums.Vulnerability.AnalysisState.FalsePositive,
         justification: Enums.Vulnerability.AnalysisJustification.ProtectedAtRuntime,
@@ -536,12 +542,21 @@ module.exports.createComplexStructure = function () {
           new Models.OrganizationalContact({ name: 'John "pentester" Doe' })
         ])
       }),
-      tools: new Models.ToolRepository([
-        new Models.Tool({
-          vendor: 'v the vendor',
-          name: 'tool name'
-        })
-      ]),
+      tools: new Models.Tools({
+        tools: new Models.ToolRepository([
+          new Models.Tool({
+            vendor: 'v the vendor',
+            name: 'tool name'
+          })
+        ]),
+        components: new Models.ComponentRepository([
+          new Models.Component(
+            Enums.ComponentType.Application,
+            'tool name', {
+              group: 'g the group'
+            })
+        ])
+      }),
       analysis: new Models.Vulnerability.Analysis({
         state: Enums.Vulnerability.AnalysisState.FalsePositive,
         justification: Enums.Vulnerability.AnalysisJustification.ProtectedAtRuntime,

--- a/tests/_data/models.js
+++ b/tests/_data/models.js
@@ -43,8 +43,8 @@ module.exports.createComplexStructure = function () {
               group: 'tool group',
               version: '0.8.15',
               hashes: new Models.HashDictionary([
-                [Enums.HashAlgorithm.MD5, 'f32a26e2a3a8aa338cd77b6e1263c535'],
-                [Enums.HashAlgorithm['SHA-1'], '829c3804401b0727f70f73d4415e162400cbe57b']
+                [Enums.HashAlgorithm.MD5, '974e5cc07da6e4536bffd935fd4ddc61'],
+                [Enums.HashAlgorithm['SHA-1'], '2aae6c35c94fcfb415dbe95f408b9ce91ee846ed']
               ])
             }),
           new Models.Component(
@@ -60,6 +60,9 @@ module.exports.createComplexStructure = function () {
                 )
               ])
             })
+        ]),
+        services: new Models.ServiceRepository([
+          new Models.Service('sbom-generator-service')
         ])
       }),
       authors: new Models.OrganizationalContactRepository([

--- a/tests/_data/models.js
+++ b/tests/_data/models.js
@@ -619,7 +619,7 @@ module.exports.createAllTools = function () {
     version: 7,
     serialNumber: `urn:uuid:${bomSerialNumberRaw}`,
   })
-  bom.metadata.tools.components.push(
+  bom.metadata.tools.components.add(
     new Models.Component(
       Enums.ComponentType.Application,
       'Component tool name', {
@@ -630,7 +630,7 @@ module.exports.createAllTools = function () {
           [Enums.HashAlgorithm['SHA-1'], '2aae6c35c94fcfb415dbe95f408b9ce91ee846ed']
         ])
       }))
-  bom.metadata.tools.services.push(
+  bom.metadata.tools.services.add(
     new Models.Service('sbom-generator-service', {
       group: 'Service tool group',
       version: '1',
@@ -643,7 +643,7 @@ module.exports.createAllTools = function () {
       ])
     })
   )
-  bom.metadata.tools.tools.push(
+  bom.metadata.tools.tools.add(
     new Models.Tool({
       vendor: 'Tool tool vendor',
       name: 'Tool tool name',
@@ -654,7 +654,7 @@ module.exports.createAllTools = function () {
       ])
     })
   )
-  bom.metadata.tools.tools.push(
+  bom.metadata.tools.tools.add(
     new Models.Tool({
       vendor: 'Tool tool vendor',
       name: 'Tool other tool',

--- a/tests/_data/models.js
+++ b/tests/_data/models.js
@@ -49,7 +49,7 @@ module.exports.createComplexStructure = function () {
             }),
           new Models.Component(
             Enums.ComponentType.Library,
-            'tool name', {
+            'other tool', {
               group: 'tool group',
               version: '', // empty string, not undefined
               externalReferences: new Models.ExternalReferenceRepository([
@@ -552,7 +552,7 @@ module.exports.createComplexStructure = function () {
         components: new Models.ComponentRepository([
           new Models.Component(
             Enums.ComponentType.Application,
-            'tool name', {
+            'other tool name', {
               group: 'g the group'
             })
         ])

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.2.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.2.json
@@ -8,6 +8,11 @@
     "timestamp": "2032-05-23T13:37:42.000Z",
     "tools": [
       {
+        "vendor": "Service service group",
+        "name": "sbom-generator-service",
+        "version": "1"
+      },
+      {
         "vendor": "tool group",
         "name": "other tool"
       },
@@ -18,11 +23,11 @@
         "hashes": [
           {
             "alg": "MD5",
-            "content": "f32a26e2a3a8aa338cd77b6e1263c535"
+            "content": "974e5cc07da6e4536bffd935fd4ddc61"
           },
           {
             "alg": "SHA-1",
-            "content": "829c3804401b0727f70f73d4415e162400cbe57b"
+            "content": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
           }
         ]
       }
@@ -338,7 +343,7 @@
       },
       "group": "acme",
       "name": "dummy-service",
-      "version": "1.2+service-version",
+      "version": "1.0+service-version",
       "description": "this is a test service",
       "licenses": [
         {

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.2.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.2.json
@@ -8,11 +8,11 @@
     "timestamp": "2032-05-23T13:37:42.000Z",
     "tools": [
       {
-        "vendor": "tool vendor",
-        "name": "other tool"
+        "vendor": "tool group",
+        "name": "tool name"
       },
       {
-        "vendor": "tool vendor",
+        "vendor": "tool group",
         "name": "tool name",
         "version": "0.8.15",
         "hashes": [

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.2.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.2.json
@@ -9,7 +9,7 @@
     "tools": [
       {
         "vendor": "tool group",
-        "name": "tool name"
+        "name": "other tool"
       },
       {
         "vendor": "tool group",

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.3.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.3.json
@@ -8,11 +8,11 @@
     "timestamp": "2032-05-23T13:37:42.000Z",
     "tools": [
       {
-        "vendor": "tool vendor",
-        "name": "other tool"
+        "vendor": "tool group",
+        "name": "tool name"
       },
       {
-        "vendor": "tool vendor",
+        "vendor": "tool group",
         "name": "tool name",
         "version": "0.8.15",
         "hashes": [

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.3.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.3.json
@@ -9,7 +9,7 @@
     "tools": [
       {
         "vendor": "tool group",
-        "name": "tool name"
+        "name": "other tool"
       },
       {
         "vendor": "tool group",

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.3.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.3.json
@@ -8,6 +8,11 @@
     "timestamp": "2032-05-23T13:37:42.000Z",
     "tools": [
       {
+        "vendor": "Service service group",
+        "name": "sbom-generator-service",
+        "version": "1"
+      },
+      {
         "vendor": "tool group",
         "name": "other tool"
       },
@@ -18,11 +23,11 @@
         "hashes": [
           {
             "alg": "MD5",
-            "content": "f32a26e2a3a8aa338cd77b6e1263c535"
+            "content": "974e5cc07da6e4536bffd935fd4ddc61"
           },
           {
             "alg": "SHA-1",
-            "content": "829c3804401b0727f70f73d4415e162400cbe57b"
+            "content": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
           }
         ]
       }
@@ -407,7 +412,7 @@
       },
       "group": "acme",
       "name": "dummy-service",
-      "version": "1.2+service-version",
+      "version": "1.0+service-version",
       "description": "this is a test service",
       "licenses": [
         {

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.4.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.4.json
@@ -8,8 +8,8 @@
     "timestamp": "2032-05-23T13:37:42.000Z",
     "tools": [
       {
-        "vendor": "tool vendor",
-        "name": "other tool",
+        "vendor": "tool group",
+        "name": "tool name",
         "externalReferences": [
           {
             "url": "https://cyclonedx.org/tool-center/",
@@ -19,7 +19,7 @@
         ]
       },
       {
-        "vendor": "tool vendor",
+        "vendor": "tool group",
         "name": "tool name",
         "version": "0.8.15",
         "hashes": [
@@ -663,6 +663,10 @@
         ]
       },
       "tools": [
+        {
+          "vendor": "g the group",
+          "name": "tool name"
+        },
         {
           "vendor": "v the vendor",
           "name": "tool name"

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.4.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.4.json
@@ -9,7 +9,7 @@
     "tools": [
       {
         "vendor": "tool group",
-        "name": "tool name",
+        "name": "other tool",
         "externalReferences": [
           {
             "url": "https://cyclonedx.org/tool-center/",
@@ -665,7 +665,7 @@
       "tools": [
         {
           "vendor": "g the group",
-          "name": "tool name"
+          "name": "other tool name"
         },
         {
           "vendor": "v the vendor",

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.4.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.4.json
@@ -8,6 +8,18 @@
     "timestamp": "2032-05-23T13:37:42.000Z",
     "tools": [
       {
+        "vendor": "Service service group",
+        "name": "sbom-generator-service",
+        "version": "1",
+        "externalReferences": [
+          {
+            "url": "https://example.com/sbom-generator-service/",
+            "type": "website",
+            "comment": "the service that made this"
+          }
+        ]
+      },
+      {
         "vendor": "tool group",
         "name": "other tool",
         "externalReferences": [
@@ -25,11 +37,11 @@
         "hashes": [
           {
             "alg": "MD5",
-            "content": "f32a26e2a3a8aa338cd77b6e1263c535"
+            "content": "974e5cc07da6e4536bffd935fd4ddc61"
           },
           {
             "alg": "SHA-1",
-            "content": "829c3804401b0727f70f73d4415e162400cbe57b"
+            "content": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
           }
         ]
       }
@@ -409,7 +421,7 @@
       },
       "group": "acme",
       "name": "dummy-service",
-      "version": "1.2+service-version",
+      "version": "1.0+service-version",
       "description": "this is a test service",
       "licenses": [
         {

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.5.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.5.json
@@ -15,34 +15,38 @@
         "phase": "design"
       }
     ],
-    "tools": [
-      {
-        "vendor": "tool vendor",
-        "name": "other tool",
-        "externalReferences": [
-          {
-            "url": "https://cyclonedx.org/tool-center/",
-            "type": "website",
-            "comment": "the tools that made this"
-          }
-        ]
-      },
-      {
-        "vendor": "tool vendor",
-        "name": "tool name",
-        "version": "0.8.15",
-        "hashes": [
-          {
-            "alg": "MD5",
-            "content": "f32a26e2a3a8aa338cd77b6e1263c535"
-          },
-          {
-            "alg": "SHA-1",
-            "content": "829c3804401b0727f70f73d4415e162400cbe57b"
-          }
-        ]
-      }
-    ],
+    "tools": {
+      "components": [
+        {
+          "type": "library",
+          "name": "tool name",
+          "group": "tool group",
+          "externalReferences": [
+            {
+              "url": "https://cyclonedx.org/tool-center/",
+              "type": "website",
+              "comment": "the tools that made this"
+            }
+          ]
+        },
+        {
+          "type": "application",
+          "name": "tool name",
+          "group": "tool group",
+          "version": "0.8.15",
+          "hashes": [
+            {
+              "alg": "MD5",
+              "content": "f32a26e2a3a8aa338cd77b6e1263c535"
+            },
+            {
+              "alg": "SHA-1",
+              "content": "829c3804401b0727f70f73d4415e162400cbe57b"
+            }
+          ]
+        }
+      ]
+    },
     "authors": [
       {
         "name": "Jane \"the-author\" Doe",
@@ -672,6 +676,10 @@
         ]
       },
       "tools": [
+        {
+          "vendor": "g the group",
+          "name": "tool name"
+        },
         {
           "vendor": "v the vendor",
           "name": "tool name"

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.5.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.5.json
@@ -19,7 +19,7 @@
       "components": [
         {
           "type": "library",
-          "name": "tool name",
+          "name": "other tool",
           "group": "tool group",
           "externalReferences": [
             {
@@ -678,7 +678,7 @@
       "tools": [
         {
           "vendor": "g the group",
-          "name": "tool name"
+          "name": "other tool name"
         },
         {
           "vendor": "v the vendor",

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.5.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.5.json
@@ -37,11 +37,25 @@
           "hashes": [
             {
               "alg": "MD5",
-              "content": "f32a26e2a3a8aa338cd77b6e1263c535"
+              "content": "974e5cc07da6e4536bffd935fd4ddc61"
             },
             {
               "alg": "SHA-1",
-              "content": "829c3804401b0727f70f73d4415e162400cbe57b"
+              "content": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
+            }
+          ]
+        }
+      ],
+      "services": [
+        {
+          "group": "Service service group",
+          "name": "sbom-generator-service",
+          "version": "1",
+          "externalReferences": [
+            {
+              "url": "https://example.com/sbom-generator-service/",
+              "type": "website",
+              "comment": "the service that made this"
             }
           ]
         }
@@ -422,7 +436,7 @@
       },
       "group": "acme",
       "name": "dummy-service",
-      "version": "1.2+service-version",
+      "version": "1.0+service-version",
       "description": "this is a test service",
       "licenses": [
         {

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.6.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.6.json
@@ -19,7 +19,7 @@
       "components": [
         {
           "type": "library",
-          "name": "tool name",
+          "name": "other tool",
           "group": "tool group",
           "externalReferences": [
             {
@@ -679,7 +679,7 @@
       "tools": [
         {
           "vendor": "g the group",
-          "name": "tool name"
+          "name": "other tool name"
         },
         {
           "vendor": "v the vendor",

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.6.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.6.json
@@ -15,34 +15,38 @@
         "phase": "design"
       }
     ],
-    "tools": [
-      {
-        "vendor": "tool vendor",
-        "name": "other tool",
-        "externalReferences": [
-          {
-            "url": "https://cyclonedx.org/tool-center/",
-            "type": "website",
-            "comment": "the tools that made this"
-          }
-        ]
-      },
-      {
-        "vendor": "tool vendor",
-        "name": "tool name",
-        "version": "0.8.15",
-        "hashes": [
-          {
-            "alg": "MD5",
-            "content": "f32a26e2a3a8aa338cd77b6e1263c535"
-          },
-          {
-            "alg": "SHA-1",
-            "content": "829c3804401b0727f70f73d4415e162400cbe57b"
-          }
-        ]
-      }
-    ],
+    "tools": {
+      "components": [
+        {
+          "type": "library",
+          "name": "tool name",
+          "group": "tool group",
+          "externalReferences": [
+            {
+              "url": "https://cyclonedx.org/tool-center/",
+              "type": "website",
+              "comment": "the tools that made this"
+            }
+          ]
+        },
+        {
+          "type": "application",
+          "name": "tool name",
+          "group": "tool group",
+          "version": "0.8.15",
+          "hashes": [
+            {
+              "alg": "MD5",
+              "content": "f32a26e2a3a8aa338cd77b6e1263c535"
+            },
+            {
+              "alg": "SHA-1",
+              "content": "829c3804401b0727f70f73d4415e162400cbe57b"
+            }
+          ]
+        }
+      ]
+    },
     "authors": [
       {
         "name": "Jane \"the-author\" Doe",
@@ -673,6 +677,10 @@
         ]
       },
       "tools": [
+        {
+          "vendor": "g the group",
+          "name": "tool name"
+        },
         {
           "vendor": "v the vendor",
           "name": "tool name"

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.6.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.6.json
@@ -37,11 +37,25 @@
           "hashes": [
             {
               "alg": "MD5",
-              "content": "f32a26e2a3a8aa338cd77b6e1263c535"
+              "content": "974e5cc07da6e4536bffd935fd4ddc61"
             },
             {
               "alg": "SHA-1",
-              "content": "829c3804401b0727f70f73d4415e162400cbe57b"
+              "content": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
+            }
+          ]
+        }
+      ],
+      "services": [
+        {
+          "group": "Service service group",
+          "name": "sbom-generator-service",
+          "version": "1",
+          "externalReferences": [
+            {
+              "url": "https://example.com/sbom-generator-service/",
+              "type": "website",
+              "comment": "the service that made this"
             }
           ]
         }
@@ -423,7 +437,7 @@
       },
       "group": "acme",
       "name": "dummy-service",
-      "version": "1.2+service-version",
+      "version": "1.0+service-version",
       "description": "this is a test service",
       "licenses": [
         {

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.2.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.2.json
@@ -27,6 +27,27 @@
                 {
                   "type": "element",
                   "name": "vendor",
+                  "children": "Service service group"
+                },
+                {
+                  "type": "element",
+                  "name": "name",
+                  "children": "sbom-generator-service"
+                },
+                {
+                  "type": "element",
+                  "name": "version",
+                  "children": "1"
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "tool",
+              "children": [
+                {
+                  "type": "element",
+                  "name": "vendor",
                   "children": "tool group"
                 },
                 {
@@ -65,7 +86,7 @@
                       "attributes": {
                         "alg": "MD5"
                       },
-                      "children": "f32a26e2a3a8aa338cd77b6e1263c535"
+                      "children": "974e5cc07da6e4536bffd935fd4ddc61"
                     },
                     {
                       "type": "element",
@@ -73,7 +94,7 @@
                       "attributes": {
                         "alg": "SHA-1"
                       },
-                      "children": "829c3804401b0727f70f73d4415e162400cbe57b"
+                      "children": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
                     }
                   ]
                 }
@@ -1084,7 +1105,7 @@
             {
               "type": "element",
               "name": "version",
-              "children": "1.2+service-version"
+              "children": "1.0+service-version"
             },
             {
               "type": "element",

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.2.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.2.json
@@ -27,12 +27,12 @@
                 {
                   "type": "element",
                   "name": "vendor",
-                  "children": "tool vendor"
+                  "children": "tool group"
                 },
                 {
                   "type": "element",
                   "name": "name",
-                  "children": "other tool"
+                  "children": "tool name"
                 }
               ]
             },
@@ -43,7 +43,7 @@
                 {
                   "type": "element",
                   "name": "vendor",
-                  "children": "tool vendor"
+                  "children": "tool group"
                 },
                 {
                   "type": "element",

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.2.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.2.json
@@ -32,7 +32,7 @@
                 {
                   "type": "element",
                   "name": "name",
-                  "children": "tool name"
+                  "children": "other tool"
                 }
               ]
             },

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.3.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.3.json
@@ -27,6 +27,27 @@
                 {
                   "type": "element",
                   "name": "vendor",
+                  "children": "Service service group"
+                },
+                {
+                  "type": "element",
+                  "name": "name",
+                  "children": "sbom-generator-service"
+                },
+                {
+                  "type": "element",
+                  "name": "version",
+                  "children": "1"
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "tool",
+              "children": [
+                {
+                  "type": "element",
+                  "name": "vendor",
                   "children": "tool group"
                 },
                 {
@@ -65,7 +86,7 @@
                       "attributes": {
                         "alg": "MD5"
                       },
-                      "children": "f32a26e2a3a8aa338cd77b6e1263c535"
+                      "children": "974e5cc07da6e4536bffd935fd4ddc61"
                     },
                     {
                       "type": "element",
@@ -73,7 +94,7 @@
                       "attributes": {
                         "alg": "SHA-1"
                       },
-                      "children": "829c3804401b0727f70f73d4415e162400cbe57b"
+                      "children": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
                     }
                   ]
                 }
@@ -1240,7 +1261,7 @@
             {
               "type": "element",
               "name": "version",
-              "children": "1.2+service-version"
+              "children": "1.0+service-version"
             },
             {
               "type": "element",

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.3.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.3.json
@@ -27,12 +27,12 @@
                 {
                   "type": "element",
                   "name": "vendor",
-                  "children": "tool vendor"
+                  "children": "tool group"
                 },
                 {
                   "type": "element",
                   "name": "name",
-                  "children": "other tool"
+                  "children": "tool name"
                 }
               ]
             },
@@ -43,7 +43,7 @@
                 {
                   "type": "element",
                   "name": "vendor",
-                  "children": "tool vendor"
+                  "children": "tool group"
                 },
                 {
                   "type": "element",

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.3.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.3.json
@@ -32,7 +32,7 @@
                 {
                   "type": "element",
                   "name": "name",
-                  "children": "tool name"
+                  "children": "other tool"
                 }
               ]
             },

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.4.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.4.json
@@ -27,12 +27,12 @@
                 {
                   "type": "element",
                   "name": "vendor",
-                  "children": "tool vendor"
+                  "children": "tool group"
                 },
                 {
                   "type": "element",
                   "name": "name",
-                  "children": "other tool"
+                  "children": "tool name"
                 },
                 {
                   "type": "element",
@@ -68,7 +68,7 @@
                 {
                   "type": "element",
                   "name": "vendor",
-                  "children": "tool vendor"
+                  "children": "tool group"
                 },
                 {
                   "type": "element",
@@ -2085,6 +2085,22 @@
               "type": "element",
               "name": "tools",
               "children": [
+                {
+                  "type": "element",
+                  "name": "tool",
+                  "children": [
+                    {
+                      "type": "element",
+                      "name": "vendor",
+                      "children": "g the group"
+                    },
+                    {
+                      "type": "element",
+                      "name": "name",
+                      "children": "tool name"
+                    }
+                  ]
+                },
                 {
                   "type": "element",
                   "name": "tool",

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.4.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.4.json
@@ -32,7 +32,7 @@
                 {
                   "type": "element",
                   "name": "name",
-                  "children": "tool name"
+                  "children": "other tool"
                 },
                 {
                   "type": "element",
@@ -2097,7 +2097,7 @@
                     {
                       "type": "element",
                       "name": "name",
-                      "children": "tool name"
+                      "children": "other tool name"
                     }
                   ]
                 },

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.4.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.4.json
@@ -27,6 +27,52 @@
                 {
                   "type": "element",
                   "name": "vendor",
+                  "children": "Service service group"
+                },
+                {
+                  "type": "element",
+                  "name": "name",
+                  "children": "sbom-generator-service"
+                },
+                {
+                  "type": "element",
+                  "name": "version",
+                  "children": "1"
+                },
+                {
+                  "type": "element",
+                  "name": "externalReferences",
+                  "children": [
+                    {
+                      "type": "element",
+                      "name": "reference",
+                      "attributes": {
+                        "type": "website"
+                      },
+                      "children": [
+                        {
+                          "type": "element",
+                          "name": "url",
+                          "children": "https://example.com/sbom-generator-service/"
+                        },
+                        {
+                          "type": "element",
+                          "name": "comment",
+                          "children": "the service that made this"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "tool",
+              "children": [
+                {
+                  "type": "element",
+                  "name": "vendor",
                   "children": "tool group"
                 },
                 {
@@ -90,7 +136,7 @@
                       "attributes": {
                         "alg": "MD5"
                       },
-                      "children": "f32a26e2a3a8aa338cd77b6e1263c535"
+                      "children": "974e5cc07da6e4536bffd935fd4ddc61"
                     },
                     {
                       "type": "element",
@@ -98,7 +144,7 @@
                       "attributes": {
                         "alg": "SHA-1"
                       },
-                      "children": "829c3804401b0727f70f73d4415e162400cbe57b"
+                      "children": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
                     }
                   ]
                 }
@@ -1234,7 +1280,7 @@
             {
               "type": "element",
               "name": "version",
-              "children": "1.2+service-version"
+              "children": "1.0+service-version"
             },
             {
               "type": "element",

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.5.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.5.json
@@ -72,7 +72,7 @@
                     {
                       "type": "element",
                       "name": "name",
-                      "children": "tool name"
+                      "children": "other tool"
                     },
                     {
                       "type": "element",
@@ -2142,7 +2142,7 @@
                     {
                       "type": "element",
                       "name": "name",
-                      "children": "tool name"
+                      "children": "other tool name"
                     }
                   ]
                 },

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.5.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.5.json
@@ -55,83 +55,95 @@
           "children": [
             {
               "type": "element",
-              "name": "tool",
+              "name": "components",
               "children": [
                 {
                   "type": "element",
-                  "name": "vendor",
-                  "children": "tool vendor"
-                },
-                {
-                  "type": "element",
-                  "name": "name",
-                  "children": "other tool"
-                },
-                {
-                  "type": "element",
-                  "name": "externalReferences",
+                  "name": "component",
+                  "attributes": {
+                    "type": "library"
+                  },
                   "children": [
                     {
                       "type": "element",
-                      "name": "reference",
-                      "attributes": {
-                        "type": "website"
-                      },
+                      "name": "group",
+                      "children": "tool group"
+                    },
+                    {
+                      "type": "element",
+                      "name": "name",
+                      "children": "tool name"
+                    },
+                    {
+                      "type": "element",
+                      "name": "externalReferences",
                       "children": [
                         {
                           "type": "element",
-                          "name": "url",
-                          "children": "https://cyclonedx.org/tool-center/"
-                        },
-                        {
-                          "type": "element",
-                          "name": "comment",
-                          "children": "the tools that made this"
+                          "name": "reference",
+                          "attributes": {
+                            "type": "website"
+                          },
+                          "children": [
+                            {
+                              "type": "element",
+                              "name": "url",
+                              "children": "https://cyclonedx.org/tool-center/"
+                            },
+                            {
+                              "type": "element",
+                              "name": "comment",
+                              "children": "the tools that made this"
+                            }
+                          ]
                         }
                       ]
                     }
                   ]
-                }
-              ]
-            },
-            {
-              "type": "element",
-              "name": "tool",
-              "children": [
-                {
-                  "type": "element",
-                  "name": "vendor",
-                  "children": "tool vendor"
                 },
                 {
                   "type": "element",
-                  "name": "name",
-                  "children": "tool name"
-                },
-                {
-                  "type": "element",
-                  "name": "version",
-                  "children": "0.8.15"
-                },
-                {
-                  "type": "element",
-                  "name": "hashes",
+                  "name": "component",
+                  "attributes": {
+                    "type": "application"
+                  },
                   "children": [
                     {
                       "type": "element",
-                      "name": "hash",
-                      "attributes": {
-                        "alg": "MD5"
-                      },
-                      "children": "f32a26e2a3a8aa338cd77b6e1263c535"
+                      "name": "group",
+                      "children": "tool group"
                     },
                     {
                       "type": "element",
-                      "name": "hash",
-                      "attributes": {
-                        "alg": "SHA-1"
-                      },
-                      "children": "829c3804401b0727f70f73d4415e162400cbe57b"
+                      "name": "name",
+                      "children": "tool name"
+                    },
+                    {
+                      "type": "element",
+                      "name": "version",
+                      "children": "0.8.15"
+                    },
+                    {
+                      "type": "element",
+                      "name": "hashes",
+                      "children": [
+                        {
+                          "type": "element",
+                          "name": "hash",
+                          "attributes": {
+                            "alg": "MD5"
+                          },
+                          "children": "f32a26e2a3a8aa338cd77b6e1263c535"
+                        },
+                        {
+                          "type": "element",
+                          "name": "hash",
+                          "attributes": {
+                            "alg": "SHA-1"
+                          },
+                          "children": "829c3804401b0727f70f73d4415e162400cbe57b"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -2118,6 +2130,22 @@
               "type": "element",
               "name": "tools",
               "children": [
+                {
+                  "type": "element",
+                  "name": "tool",
+                  "children": [
+                    {
+                      "type": "element",
+                      "name": "vendor",
+                      "children": "g the group"
+                    },
+                    {
+                      "type": "element",
+                      "name": "name",
+                      "children": "tool name"
+                    }
+                  ]
+                },
                 {
                   "type": "element",
                   "name": "tool",

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.5.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.5.json
@@ -133,7 +133,7 @@
                           "attributes": {
                             "alg": "MD5"
                           },
-                          "children": "f32a26e2a3a8aa338cd77b6e1263c535"
+                          "children": "974e5cc07da6e4536bffd935fd4ddc61"
                         },
                         {
                           "type": "element",
@@ -141,7 +141,60 @@
                           "attributes": {
                             "alg": "SHA-1"
                           },
-                          "children": "829c3804401b0727f70f73d4415e162400cbe57b"
+                          "children": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "services",
+              "children": [
+                {
+                  "type": "element",
+                  "name": "service",
+                  "attributes": {},
+                  "children": [
+                    {
+                      "type": "element",
+                      "name": "group",
+                      "children": "Service service group"
+                    },
+                    {
+                      "type": "element",
+                      "name": "name",
+                      "children": "sbom-generator-service"
+                    },
+                    {
+                      "type": "element",
+                      "name": "version",
+                      "children": "1"
+                    },
+                    {
+                      "type": "element",
+                      "name": "externalReferences",
+                      "children": [
+                        {
+                          "type": "element",
+                          "name": "reference",
+                          "attributes": {
+                            "type": "website"
+                          },
+                          "children": [
+                            {
+                              "type": "element",
+                              "name": "url",
+                              "children": "https://example.com/sbom-generator-service/"
+                            },
+                            {
+                              "type": "element",
+                              "name": "comment",
+                              "children": "the service that made this"
+                            }
+                          ]
                         }
                       ]
                     }
@@ -1279,7 +1332,7 @@
             {
               "type": "element",
               "name": "version",
-              "children": "1.2+service-version"
+              "children": "1.0+service-version"
             },
             {
               "type": "element",

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.6.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.6.json
@@ -72,7 +72,7 @@
                     {
                       "type": "element",
                       "name": "name",
-                      "children": "tool name"
+                      "children": "other tool"
                     },
                     {
                       "type": "element",
@@ -2144,7 +2144,7 @@
                     {
                       "type": "element",
                       "name": "name",
-                      "children": "tool name"
+                      "children": "other tool name"
                     }
                   ]
                 },

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.6.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.6.json
@@ -133,7 +133,7 @@
                           "attributes": {
                             "alg": "MD5"
                           },
-                          "children": "f32a26e2a3a8aa338cd77b6e1263c535"
+                          "children": "974e5cc07da6e4536bffd935fd4ddc61"
                         },
                         {
                           "type": "element",
@@ -141,7 +141,60 @@
                           "attributes": {
                             "alg": "SHA-1"
                           },
-                          "children": "829c3804401b0727f70f73d4415e162400cbe57b"
+                          "children": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "services",
+              "children": [
+                {
+                  "type": "element",
+                  "name": "service",
+                  "attributes": {},
+                  "children": [
+                    {
+                      "type": "element",
+                      "name": "group",
+                      "children": "Service service group"
+                    },
+                    {
+                      "type": "element",
+                      "name": "name",
+                      "children": "sbom-generator-service"
+                    },
+                    {
+                      "type": "element",
+                      "name": "version",
+                      "children": "1"
+                    },
+                    {
+                      "type": "element",
+                      "name": "externalReferences",
+                      "children": [
+                        {
+                          "type": "element",
+                          "name": "reference",
+                          "attributes": {
+                            "type": "website"
+                          },
+                          "children": [
+                            {
+                              "type": "element",
+                              "name": "url",
+                              "children": "https://example.com/sbom-generator-service/"
+                            },
+                            {
+                              "type": "element",
+                              "name": "comment",
+                              "children": "the service that made this"
+                            }
+                          ]
                         }
                       ]
                     }
@@ -1281,7 +1334,7 @@
             {
               "type": "element",
               "name": "version",
-              "children": "1.2+service-version"
+              "children": "1.0+service-version"
             },
             {
               "type": "element",

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.6.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.6.json
@@ -55,83 +55,95 @@
           "children": [
             {
               "type": "element",
-              "name": "tool",
+              "name": "components",
               "children": [
                 {
                   "type": "element",
-                  "name": "vendor",
-                  "children": "tool vendor"
-                },
-                {
-                  "type": "element",
-                  "name": "name",
-                  "children": "other tool"
-                },
-                {
-                  "type": "element",
-                  "name": "externalReferences",
+                  "name": "component",
+                  "attributes": {
+                    "type": "library"
+                  },
                   "children": [
                     {
                       "type": "element",
-                      "name": "reference",
-                      "attributes": {
-                        "type": "website"
-                      },
+                      "name": "group",
+                      "children": "tool group"
+                    },
+                    {
+                      "type": "element",
+                      "name": "name",
+                      "children": "tool name"
+                    },
+                    {
+                      "type": "element",
+                      "name": "externalReferences",
                       "children": [
                         {
                           "type": "element",
-                          "name": "url",
-                          "children": "https://cyclonedx.org/tool-center/"
-                        },
-                        {
-                          "type": "element",
-                          "name": "comment",
-                          "children": "the tools that made this"
+                          "name": "reference",
+                          "attributes": {
+                            "type": "website"
+                          },
+                          "children": [
+                            {
+                              "type": "element",
+                              "name": "url",
+                              "children": "https://cyclonedx.org/tool-center/"
+                            },
+                            {
+                              "type": "element",
+                              "name": "comment",
+                              "children": "the tools that made this"
+                            }
+                          ]
                         }
                       ]
                     }
                   ]
-                }
-              ]
-            },
-            {
-              "type": "element",
-              "name": "tool",
-              "children": [
-                {
-                  "type": "element",
-                  "name": "vendor",
-                  "children": "tool vendor"
                 },
                 {
                   "type": "element",
-                  "name": "name",
-                  "children": "tool name"
-                },
-                {
-                  "type": "element",
-                  "name": "version",
-                  "children": "0.8.15"
-                },
-                {
-                  "type": "element",
-                  "name": "hashes",
+                  "name": "component",
+                  "attributes": {
+                    "type": "application"
+                  },
                   "children": [
                     {
                       "type": "element",
-                      "name": "hash",
-                      "attributes": {
-                        "alg": "MD5"
-                      },
-                      "children": "f32a26e2a3a8aa338cd77b6e1263c535"
+                      "name": "group",
+                      "children": "tool group"
                     },
                     {
                       "type": "element",
-                      "name": "hash",
-                      "attributes": {
-                        "alg": "SHA-1"
-                      },
-                      "children": "829c3804401b0727f70f73d4415e162400cbe57b"
+                      "name": "name",
+                      "children": "tool name"
+                    },
+                    {
+                      "type": "element",
+                      "name": "version",
+                      "children": "0.8.15"
+                    },
+                    {
+                      "type": "element",
+                      "name": "hashes",
+                      "children": [
+                        {
+                          "type": "element",
+                          "name": "hash",
+                          "attributes": {
+                            "alg": "MD5"
+                          },
+                          "children": "f32a26e2a3a8aa338cd77b6e1263c535"
+                        },
+                        {
+                          "type": "element",
+                          "name": "hash",
+                          "attributes": {
+                            "alg": "SHA-1"
+                          },
+                          "children": "829c3804401b0727f70f73d4415e162400cbe57b"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -2120,6 +2132,22 @@
               "type": "element",
               "name": "tools",
               "children": [
+                {
+                  "type": "element",
+                  "name": "tool",
+                  "children": [
+                    {
+                      "type": "element",
+                      "name": "vendor",
+                      "children": "g the group"
+                    },
+                    {
+                      "type": "element",
+                      "name": "name",
+                      "children": "tool name"
+                    }
+                  ]
+                },
                 {
                   "type": "element",
                   "name": "tool",

--- a/tests/_data/serializeResults/json_allTools_spec1.2.json.bin
+++ b/tests/_data/serializeResults/json_allTools_spec1.2.json.bin
@@ -1,0 +1,52 @@
+{
+    "$schema": "http://cyclonedx.org/schema/bom-1.2b.schema.json",
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.2",
+    "version": 7,
+    "serialNumber": "urn:uuid:8fd9e244-73b6-4cd3-ab3a-a0fefdee5c9e",
+    "metadata": {
+        "tools": [
+            {
+                "vendor": "Component tool group",
+                "name": "Component tool name",
+                "version": "0.8.15",
+                "hashes": [
+                    {
+                        "alg": "MD5",
+                        "content": "974e5cc07da6e4536bffd935fd4ddc61"
+                    },
+                    {
+                        "alg": "SHA-1",
+                        "content": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
+                    }
+                ]
+            },
+            {
+                "vendor": "Service tool group",
+                "name": "sbom-generator-service",
+                "version": "1"
+            },
+            {
+                "vendor": "Tool tool vendor",
+                "name": "Tool other tool"
+            },
+            {
+                "vendor": "Tool tool vendor",
+                "name": "Tool tool name",
+                "version": "0.8.15",
+                "hashes": [
+                    {
+                        "alg": "MD5",
+                        "content": "f32a26e2a3a8aa338cd77b6e1263c535"
+                    },
+                    {
+                        "alg": "SHA-1",
+                        "content": "829c3804401b0727f70f73d4415e162400cbe57b"
+                    }
+                ]
+            }
+        ]
+    },
+    "components": [],
+    "dependencies": []
+}

--- a/tests/_data/serializeResults/json_allTools_spec1.3.json.bin
+++ b/tests/_data/serializeResults/json_allTools_spec1.3.json.bin
@@ -1,0 +1,52 @@
+{
+    "$schema": "http://cyclonedx.org/schema/bom-1.3a.schema.json",
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.3",
+    "version": 7,
+    "serialNumber": "urn:uuid:8fd9e244-73b6-4cd3-ab3a-a0fefdee5c9e",
+    "metadata": {
+        "tools": [
+            {
+                "vendor": "Component tool group",
+                "name": "Component tool name",
+                "version": "0.8.15",
+                "hashes": [
+                    {
+                        "alg": "MD5",
+                        "content": "974e5cc07da6e4536bffd935fd4ddc61"
+                    },
+                    {
+                        "alg": "SHA-1",
+                        "content": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
+                    }
+                ]
+            },
+            {
+                "vendor": "Service tool group",
+                "name": "sbom-generator-service",
+                "version": "1"
+            },
+            {
+                "vendor": "Tool tool vendor",
+                "name": "Tool other tool"
+            },
+            {
+                "vendor": "Tool tool vendor",
+                "name": "Tool tool name",
+                "version": "0.8.15",
+                "hashes": [
+                    {
+                        "alg": "MD5",
+                        "content": "f32a26e2a3a8aa338cd77b6e1263c535"
+                    },
+                    {
+                        "alg": "SHA-1",
+                        "content": "829c3804401b0727f70f73d4415e162400cbe57b"
+                    }
+                ]
+            }
+        ]
+    },
+    "components": [],
+    "dependencies": []
+}

--- a/tests/_data/serializeResults/json_allTools_spec1.4.json.bin
+++ b/tests/_data/serializeResults/json_allTools_spec1.4.json.bin
@@ -1,0 +1,66 @@
+{
+    "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    "version": 7,
+    "serialNumber": "urn:uuid:8fd9e244-73b6-4cd3-ab3a-a0fefdee5c9e",
+    "metadata": {
+        "tools": [
+            {
+                "vendor": "Component tool group",
+                "name": "Component tool name",
+                "version": "0.8.15",
+                "hashes": [
+                    {
+                        "alg": "MD5",
+                        "content": "974e5cc07da6e4536bffd935fd4ddc61"
+                    },
+                    {
+                        "alg": "SHA-1",
+                        "content": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
+                    }
+                ]
+            },
+            {
+                "vendor": "Service tool group",
+                "name": "sbom-generator-service",
+                "version": "1",
+                "externalReferences": [
+                    {
+                        "url": "https://example.com/sbom-generator-service/",
+                        "type": "website",
+                        "comment": "the service that made this"
+                    }
+                ]
+            },
+            {
+                "vendor": "Tool tool vendor",
+                "name": "Tool other tool",
+                "externalReferences": [
+                    {
+                        "url": "https://cyclonedx.org/tool-center/",
+                        "type": "website",
+                        "comment": "the tools that made this"
+                    }
+                ]
+            },
+            {
+                "vendor": "Tool tool vendor",
+                "name": "Tool tool name",
+                "version": "0.8.15",
+                "hashes": [
+                    {
+                        "alg": "MD5",
+                        "content": "f32a26e2a3a8aa338cd77b6e1263c535"
+                    },
+                    {
+                        "alg": "SHA-1",
+                        "content": "829c3804401b0727f70f73d4415e162400cbe57b"
+                    }
+                ]
+            }
+        ]
+    },
+    "components": [],
+    "dependencies": []
+}

--- a/tests/_data/serializeResults/json_allTools_spec1.5.json.bin
+++ b/tests/_data/serializeResults/json_allTools_spec1.5.json.bin
@@ -1,0 +1,66 @@
+{
+    "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.5",
+    "version": 7,
+    "serialNumber": "urn:uuid:8fd9e244-73b6-4cd3-ab3a-a0fefdee5c9e",
+    "metadata": {
+        "tools": [
+            {
+                "vendor": "Component tool group",
+                "name": "Component tool name",
+                "version": "0.8.15",
+                "hashes": [
+                    {
+                        "alg": "MD5",
+                        "content": "974e5cc07da6e4536bffd935fd4ddc61"
+                    },
+                    {
+                        "alg": "SHA-1",
+                        "content": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
+                    }
+                ]
+            },
+            {
+                "vendor": "Service tool group",
+                "name": "sbom-generator-service",
+                "version": "1",
+                "externalReferences": [
+                    {
+                        "url": "https://example.com/sbom-generator-service/",
+                        "type": "website",
+                        "comment": "the service that made this"
+                    }
+                ]
+            },
+            {
+                "vendor": "Tool tool vendor",
+                "name": "Tool other tool",
+                "externalReferences": [
+                    {
+                        "url": "https://cyclonedx.org/tool-center/",
+                        "type": "website",
+                        "comment": "the tools that made this"
+                    }
+                ]
+            },
+            {
+                "vendor": "Tool tool vendor",
+                "name": "Tool tool name",
+                "version": "0.8.15",
+                "hashes": [
+                    {
+                        "alg": "MD5",
+                        "content": "f32a26e2a3a8aa338cd77b6e1263c535"
+                    },
+                    {
+                        "alg": "SHA-1",
+                        "content": "829c3804401b0727f70f73d4415e162400cbe57b"
+                    }
+                ]
+            }
+        ]
+    },
+    "components": [],
+    "dependencies": []
+}

--- a/tests/_data/serializeResults/json_allTools_spec1.6.json.bin
+++ b/tests/_data/serializeResults/json_allTools_spec1.6.json.bin
@@ -1,0 +1,66 @@
+{
+    "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.6",
+    "version": 7,
+    "serialNumber": "urn:uuid:8fd9e244-73b6-4cd3-ab3a-a0fefdee5c9e",
+    "metadata": {
+        "tools": [
+            {
+                "vendor": "Component tool group",
+                "name": "Component tool name",
+                "version": "0.8.15",
+                "hashes": [
+                    {
+                        "alg": "MD5",
+                        "content": "974e5cc07da6e4536bffd935fd4ddc61"
+                    },
+                    {
+                        "alg": "SHA-1",
+                        "content": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
+                    }
+                ]
+            },
+            {
+                "vendor": "Service tool group",
+                "name": "sbom-generator-service",
+                "version": "1",
+                "externalReferences": [
+                    {
+                        "url": "https://example.com/sbom-generator-service/",
+                        "type": "website",
+                        "comment": "the service that made this"
+                    }
+                ]
+            },
+            {
+                "vendor": "Tool tool vendor",
+                "name": "Tool other tool",
+                "externalReferences": [
+                    {
+                        "url": "https://cyclonedx.org/tool-center/",
+                        "type": "website",
+                        "comment": "the tools that made this"
+                    }
+                ]
+            },
+            {
+                "vendor": "Tool tool vendor",
+                "name": "Tool tool name",
+                "version": "0.8.15",
+                "hashes": [
+                    {
+                        "alg": "MD5",
+                        "content": "f32a26e2a3a8aa338cd77b6e1263c535"
+                    },
+                    {
+                        "alg": "SHA-1",
+                        "content": "829c3804401b0727f70f73d4415e162400cbe57b"
+                    }
+                ]
+            }
+        ]
+    },
+    "components": [],
+    "dependencies": []
+}

--- a/tests/_data/serializeResults/json_complex_spec1.2.json.bin
+++ b/tests/_data/serializeResults/json_complex_spec1.2.json.bin
@@ -8,21 +8,26 @@
         "timestamp": "2032-05-23T13:37:42.000Z",
         "tools": [
             {
-                "vendor": "tool vendor",
+                "vendor": "Service service group",
+                "name": "sbom-generator-service",
+                "version": "1"
+            },
+            {
+                "vendor": "tool group",
                 "name": "other tool"
             },
             {
-                "vendor": "tool vendor",
+                "vendor": "tool group",
                 "name": "tool name",
                 "version": "0.8.15",
                 "hashes": [
                     {
                         "alg": "MD5",
-                        "content": "f32a26e2a3a8aa338cd77b6e1263c535"
+                        "content": "974e5cc07da6e4536bffd935fd4ddc61"
                     },
                     {
                         "alg": "SHA-1",
-                        "content": "829c3804401b0727f70f73d4415e162400cbe57b"
+                        "content": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
                     }
                 ]
             }
@@ -338,7 +343,7 @@
             },
             "group": "acme",
             "name": "dummy-service",
-            "version": "1.2+service-version",
+            "version": "1.0+service-version",
             "description": "this is a test service",
             "licenses": [
                 {

--- a/tests/_data/serializeResults/json_complex_spec1.3.json.bin
+++ b/tests/_data/serializeResults/json_complex_spec1.3.json.bin
@@ -8,21 +8,26 @@
         "timestamp": "2032-05-23T13:37:42.000Z",
         "tools": [
             {
-                "vendor": "tool vendor",
+                "vendor": "Service service group",
+                "name": "sbom-generator-service",
+                "version": "1"
+            },
+            {
+                "vendor": "tool group",
                 "name": "other tool"
             },
             {
-                "vendor": "tool vendor",
+                "vendor": "tool group",
                 "name": "tool name",
                 "version": "0.8.15",
                 "hashes": [
                     {
                         "alg": "MD5",
-                        "content": "f32a26e2a3a8aa338cd77b6e1263c535"
+                        "content": "974e5cc07da6e4536bffd935fd4ddc61"
                     },
                     {
                         "alg": "SHA-1",
-                        "content": "829c3804401b0727f70f73d4415e162400cbe57b"
+                        "content": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
                     }
                 ]
             }
@@ -407,7 +412,7 @@
             },
             "group": "acme",
             "name": "dummy-service",
-            "version": "1.2+service-version",
+            "version": "1.0+service-version",
             "description": "this is a test service",
             "licenses": [
                 {

--- a/tests/_data/serializeResults/json_complex_spec1.4.json.bin
+++ b/tests/_data/serializeResults/json_complex_spec1.4.json.bin
@@ -8,7 +8,19 @@
         "timestamp": "2032-05-23T13:37:42.000Z",
         "tools": [
             {
-                "vendor": "tool vendor",
+                "vendor": "Service service group",
+                "name": "sbom-generator-service",
+                "version": "1",
+                "externalReferences": [
+                    {
+                        "url": "https://example.com/sbom-generator-service/",
+                        "type": "website",
+                        "comment": "the service that made this"
+                    }
+                ]
+            },
+            {
+                "vendor": "tool group",
                 "name": "other tool",
                 "externalReferences": [
                     {
@@ -19,17 +31,17 @@
                 ]
             },
             {
-                "vendor": "tool vendor",
+                "vendor": "tool group",
                 "name": "tool name",
                 "version": "0.8.15",
                 "hashes": [
                     {
                         "alg": "MD5",
-                        "content": "f32a26e2a3a8aa338cd77b6e1263c535"
+                        "content": "974e5cc07da6e4536bffd935fd4ddc61"
                     },
                     {
                         "alg": "SHA-1",
-                        "content": "829c3804401b0727f70f73d4415e162400cbe57b"
+                        "content": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
                     }
                 ]
             }
@@ -409,7 +421,7 @@
             },
             "group": "acme",
             "name": "dummy-service",
-            "version": "1.2+service-version",
+            "version": "1.0+service-version",
             "description": "this is a test service",
             "licenses": [
                 {
@@ -663,6 +675,10 @@
                 ]
             },
             "tools": [
+                {
+                    "vendor": "g the group",
+                    "name": "other tool name"
+                },
                 {
                     "vendor": "v the vendor",
                     "name": "tool name"

--- a/tests/_data/serializeResults/json_complex_spec1.5.json.bin
+++ b/tests/_data/serializeResults/json_complex_spec1.5.json.bin
@@ -15,34 +15,52 @@
                 "phase": "design"
             }
         ],
-        "tools": [
-            {
-                "vendor": "tool vendor",
-                "name": "other tool",
-                "externalReferences": [
-                    {
-                        "url": "https://cyclonedx.org/tool-center/",
-                        "type": "website",
-                        "comment": "the tools that made this"
-                    }
-                ]
-            },
-            {
-                "vendor": "tool vendor",
-                "name": "tool name",
-                "version": "0.8.15",
-                "hashes": [
-                    {
-                        "alg": "MD5",
-                        "content": "f32a26e2a3a8aa338cd77b6e1263c535"
-                    },
-                    {
-                        "alg": "SHA-1",
-                        "content": "829c3804401b0727f70f73d4415e162400cbe57b"
-                    }
-                ]
-            }
-        ],
+        "tools": {
+            "components": [
+                {
+                    "type": "library",
+                    "name": "other tool",
+                    "group": "tool group",
+                    "externalReferences": [
+                        {
+                            "url": "https://cyclonedx.org/tool-center/",
+                            "type": "website",
+                            "comment": "the tools that made this"
+                        }
+                    ]
+                },
+                {
+                    "type": "application",
+                    "name": "tool name",
+                    "group": "tool group",
+                    "version": "0.8.15",
+                    "hashes": [
+                        {
+                            "alg": "MD5",
+                            "content": "974e5cc07da6e4536bffd935fd4ddc61"
+                        },
+                        {
+                            "alg": "SHA-1",
+                            "content": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
+                        }
+                    ]
+                }
+            ],
+            "services": [
+                {
+                    "group": "Service service group",
+                    "name": "sbom-generator-service",
+                    "version": "1",
+                    "externalReferences": [
+                        {
+                            "url": "https://example.com/sbom-generator-service/",
+                            "type": "website",
+                            "comment": "the service that made this"
+                        }
+                    ]
+                }
+            ]
+        },
         "authors": [
             {
                 "name": "Jane \"the-author\" Doe",
@@ -418,7 +436,7 @@
             },
             "group": "acme",
             "name": "dummy-service",
-            "version": "1.2+service-version",
+            "version": "1.0+service-version",
             "description": "this is a test service",
             "licenses": [
                 {
@@ -672,6 +690,10 @@
                 ]
             },
             "tools": [
+                {
+                    "vendor": "g the group",
+                    "name": "other tool name"
+                },
                 {
                     "vendor": "v the vendor",
                     "name": "tool name"

--- a/tests/_data/serializeResults/json_complex_spec1.6.json.bin
+++ b/tests/_data/serializeResults/json_complex_spec1.6.json.bin
@@ -15,34 +15,52 @@
                 "phase": "design"
             }
         ],
-        "tools": [
-            {
-                "vendor": "tool vendor",
-                "name": "other tool",
-                "externalReferences": [
-                    {
-                        "url": "https://cyclonedx.org/tool-center/",
-                        "type": "website",
-                        "comment": "the tools that made this"
-                    }
-                ]
-            },
-            {
-                "vendor": "tool vendor",
-                "name": "tool name",
-                "version": "0.8.15",
-                "hashes": [
-                    {
-                        "alg": "MD5",
-                        "content": "f32a26e2a3a8aa338cd77b6e1263c535"
-                    },
-                    {
-                        "alg": "SHA-1",
-                        "content": "829c3804401b0727f70f73d4415e162400cbe57b"
-                    }
-                ]
-            }
-        ],
+        "tools": {
+            "components": [
+                {
+                    "type": "library",
+                    "name": "other tool",
+                    "group": "tool group",
+                    "externalReferences": [
+                        {
+                            "url": "https://cyclonedx.org/tool-center/",
+                            "type": "website",
+                            "comment": "the tools that made this"
+                        }
+                    ]
+                },
+                {
+                    "type": "application",
+                    "name": "tool name",
+                    "group": "tool group",
+                    "version": "0.8.15",
+                    "hashes": [
+                        {
+                            "alg": "MD5",
+                            "content": "974e5cc07da6e4536bffd935fd4ddc61"
+                        },
+                        {
+                            "alg": "SHA-1",
+                            "content": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
+                        }
+                    ]
+                }
+            ],
+            "services": [
+                {
+                    "group": "Service service group",
+                    "name": "sbom-generator-service",
+                    "version": "1",
+                    "externalReferences": [
+                        {
+                            "url": "https://example.com/sbom-generator-service/",
+                            "type": "website",
+                            "comment": "the service that made this"
+                        }
+                    ]
+                }
+            ]
+        },
         "authors": [
             {
                 "name": "Jane \"the-author\" Doe",
@@ -419,7 +437,7 @@
             },
             "group": "acme",
             "name": "dummy-service",
-            "version": "1.2+service-version",
+            "version": "1.0+service-version",
             "description": "this is a test service",
             "licenses": [
                 {
@@ -673,6 +691,10 @@
                 ]
             },
             "tools": [
+                {
+                    "vendor": "g the group",
+                    "name": "other tool name"
+                },
                 {
                     "vendor": "v the vendor",
                     "name": "tool name"

--- a/tests/_data/serializeResults/xml_allTools_spec1.2.xml.bin
+++ b/tests/_data/serializeResults/xml_allTools_spec1.2.xml.bin
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.2" version="7" serialNumber="urn:uuid:8fd9e244-73b6-4cd3-ab3a-a0fefdee5c9e">
+    <metadata>
+        <tools>
+            <tool>
+                <vendor>Component tool group</vendor>
+                <name>Component tool name</name>
+                <version>0.8.15</version>
+                <hashes>
+                    <hash alg="MD5">974e5cc07da6e4536bffd935fd4ddc61</hash>
+                    <hash alg="SHA-1">2aae6c35c94fcfb415dbe95f408b9ce91ee846ed</hash>
+                </hashes>
+            </tool>
+            <tool>
+                <vendor>Service tool group</vendor>
+                <name>sbom-generator-service</name>
+                <version>1</version>
+            </tool>
+            <tool>
+                <vendor>Tool tool vendor</vendor>
+                <name>Tool other tool</name>
+            </tool>
+            <tool>
+                <vendor>Tool tool vendor</vendor>
+                <name>Tool tool name</name>
+                <version>0.8.15</version>
+                <hashes>
+                    <hash alg="MD5">f32a26e2a3a8aa338cd77b6e1263c535</hash>
+                    <hash alg="SHA-1">829c3804401b0727f70f73d4415e162400cbe57b</hash>
+                </hashes>
+            </tool>
+        </tools>
+    </metadata>
+    <components/>
+    <dependencies/>
+</bom>

--- a/tests/_data/serializeResults/xml_allTools_spec1.3.xml.bin
+++ b/tests/_data/serializeResults/xml_allTools_spec1.3.xml.bin
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" version="7" serialNumber="urn:uuid:8fd9e244-73b6-4cd3-ab3a-a0fefdee5c9e">
+    <metadata>
+        <tools>
+            <tool>
+                <vendor>Component tool group</vendor>
+                <name>Component tool name</name>
+                <version>0.8.15</version>
+                <hashes>
+                    <hash alg="MD5">974e5cc07da6e4536bffd935fd4ddc61</hash>
+                    <hash alg="SHA-1">2aae6c35c94fcfb415dbe95f408b9ce91ee846ed</hash>
+                </hashes>
+            </tool>
+            <tool>
+                <vendor>Service tool group</vendor>
+                <name>sbom-generator-service</name>
+                <version>1</version>
+            </tool>
+            <tool>
+                <vendor>Tool tool vendor</vendor>
+                <name>Tool other tool</name>
+            </tool>
+            <tool>
+                <vendor>Tool tool vendor</vendor>
+                <name>Tool tool name</name>
+                <version>0.8.15</version>
+                <hashes>
+                    <hash alg="MD5">f32a26e2a3a8aa338cd77b6e1263c535</hash>
+                    <hash alg="SHA-1">829c3804401b0727f70f73d4415e162400cbe57b</hash>
+                </hashes>
+            </tool>
+        </tools>
+    </metadata>
+    <components/>
+    <dependencies/>
+</bom>

--- a/tests/_data/serializeResults/xml_allTools_spec1.4.xml.bin
+++ b/tests/_data/serializeResults/xml_allTools_spec1.4.xml.bin
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.4" version="7" serialNumber="urn:uuid:8fd9e244-73b6-4cd3-ab3a-a0fefdee5c9e">
+    <metadata>
+        <tools>
+            <tool>
+                <vendor>Component tool group</vendor>
+                <name>Component tool name</name>
+                <version>0.8.15</version>
+                <hashes>
+                    <hash alg="MD5">974e5cc07da6e4536bffd935fd4ddc61</hash>
+                    <hash alg="SHA-1">2aae6c35c94fcfb415dbe95f408b9ce91ee846ed</hash>
+                </hashes>
+            </tool>
+            <tool>
+                <vendor>Service tool group</vendor>
+                <name>sbom-generator-service</name>
+                <version>1</version>
+                <externalReferences>
+                    <reference type="website">
+                        <url>https://example.com/sbom-generator-service/</url>
+                        <comment>the service that made this</comment>
+                    </reference>
+                </externalReferences>
+            </tool>
+            <tool>
+                <vendor>Tool tool vendor</vendor>
+                <name>Tool other tool</name>
+                <externalReferences>
+                    <reference type="website">
+                        <url>https://cyclonedx.org/tool-center/</url>
+                        <comment>the tools that made this</comment>
+                    </reference>
+                </externalReferences>
+            </tool>
+            <tool>
+                <vendor>Tool tool vendor</vendor>
+                <name>Tool tool name</name>
+                <version>0.8.15</version>
+                <hashes>
+                    <hash alg="MD5">f32a26e2a3a8aa338cd77b6e1263c535</hash>
+                    <hash alg="SHA-1">829c3804401b0727f70f73d4415e162400cbe57b</hash>
+                </hashes>
+            </tool>
+        </tools>
+    </metadata>
+    <components/>
+    <dependencies/>
+</bom>

--- a/tests/_data/serializeResults/xml_allTools_spec1.5.xml.bin
+++ b/tests/_data/serializeResults/xml_allTools_spec1.5.xml.bin
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="7" serialNumber="urn:uuid:8fd9e244-73b6-4cd3-ab3a-a0fefdee5c9e">
+    <metadata>
+        <tools>
+            <tool>
+                <vendor>Component tool group</vendor>
+                <name>Component tool name</name>
+                <version>0.8.15</version>
+                <hashes>
+                    <hash alg="MD5">974e5cc07da6e4536bffd935fd4ddc61</hash>
+                    <hash alg="SHA-1">2aae6c35c94fcfb415dbe95f408b9ce91ee846ed</hash>
+                </hashes>
+            </tool>
+            <tool>
+                <vendor>Service tool group</vendor>
+                <name>sbom-generator-service</name>
+                <version>1</version>
+                <externalReferences>
+                    <reference type="website">
+                        <url>https://example.com/sbom-generator-service/</url>
+                        <comment>the service that made this</comment>
+                    </reference>
+                </externalReferences>
+            </tool>
+            <tool>
+                <vendor>Tool tool vendor</vendor>
+                <name>Tool other tool</name>
+                <externalReferences>
+                    <reference type="website">
+                        <url>https://cyclonedx.org/tool-center/</url>
+                        <comment>the tools that made this</comment>
+                    </reference>
+                </externalReferences>
+            </tool>
+            <tool>
+                <vendor>Tool tool vendor</vendor>
+                <name>Tool tool name</name>
+                <version>0.8.15</version>
+                <hashes>
+                    <hash alg="MD5">f32a26e2a3a8aa338cd77b6e1263c535</hash>
+                    <hash alg="SHA-1">829c3804401b0727f70f73d4415e162400cbe57b</hash>
+                </hashes>
+            </tool>
+        </tools>
+    </metadata>
+    <components/>
+    <dependencies/>
+</bom>

--- a/tests/_data/serializeResults/xml_allTools_spec1.6.xml.bin
+++ b/tests/_data/serializeResults/xml_allTools_spec1.6.xml.bin
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="7" serialNumber="urn:uuid:8fd9e244-73b6-4cd3-ab3a-a0fefdee5c9e">
+    <metadata>
+        <tools>
+            <tool>
+                <vendor>Component tool group</vendor>
+                <name>Component tool name</name>
+                <version>0.8.15</version>
+                <hashes>
+                    <hash alg="MD5">974e5cc07da6e4536bffd935fd4ddc61</hash>
+                    <hash alg="SHA-1">2aae6c35c94fcfb415dbe95f408b9ce91ee846ed</hash>
+                </hashes>
+            </tool>
+            <tool>
+                <vendor>Service tool group</vendor>
+                <name>sbom-generator-service</name>
+                <version>1</version>
+                <externalReferences>
+                    <reference type="website">
+                        <url>https://example.com/sbom-generator-service/</url>
+                        <comment>the service that made this</comment>
+                    </reference>
+                </externalReferences>
+            </tool>
+            <tool>
+                <vendor>Tool tool vendor</vendor>
+                <name>Tool other tool</name>
+                <externalReferences>
+                    <reference type="website">
+                        <url>https://cyclonedx.org/tool-center/</url>
+                        <comment>the tools that made this</comment>
+                    </reference>
+                </externalReferences>
+            </tool>
+            <tool>
+                <vendor>Tool tool vendor</vendor>
+                <name>Tool tool name</name>
+                <version>0.8.15</version>
+                <hashes>
+                    <hash alg="MD5">f32a26e2a3a8aa338cd77b6e1263c535</hash>
+                    <hash alg="SHA-1">829c3804401b0727f70f73d4415e162400cbe57b</hash>
+                </hashes>
+            </tool>
+        </tools>
+    </metadata>
+    <components/>
+    <dependencies/>
+</bom>

--- a/tests/_data/serializeResults/xml_complex_spec1.2.xml.bin
+++ b/tests/_data/serializeResults/xml_complex_spec1.2.xml.bin
@@ -4,16 +4,21 @@
         <timestamp>2032-05-23T13:37:42.000Z</timestamp>
         <tools>
             <tool>
-                <vendor>tool vendor</vendor>
+                <vendor>Service service group</vendor>
+                <name>sbom-generator-service</name>
+                <version>1</version>
+            </tool>
+            <tool>
+                <vendor>tool group</vendor>
                 <name>other tool</name>
             </tool>
             <tool>
-                <vendor>tool vendor</vendor>
+                <vendor>tool group</vendor>
                 <name>tool name</name>
                 <version>0.8.15</version>
                 <hashes>
-                    <hash alg="MD5">f32a26e2a3a8aa338cd77b6e1263c535</hash>
-                    <hash alg="SHA-1">829c3804401b0727f70f73d4415e162400cbe57b</hash>
+                    <hash alg="MD5">974e5cc07da6e4536bffd935fd4ddc61</hash>
+                    <hash alg="SHA-1">2aae6c35c94fcfb415dbe95f408b9ce91ee846ed</hash>
                 </hashes>
             </tool>
         </tools>
@@ -237,7 +242,7 @@
             </provider>
             <group>acme</group>
             <name>dummy-service</name>
-            <version>1.2+service-version</version>
+            <version>1.0+service-version</version>
             <description>this is a test service</description>
             <licenses>
                 <license>

--- a/tests/_data/serializeResults/xml_complex_spec1.3.xml.bin
+++ b/tests/_data/serializeResults/xml_complex_spec1.3.xml.bin
@@ -4,16 +4,21 @@
         <timestamp>2032-05-23T13:37:42.000Z</timestamp>
         <tools>
             <tool>
-                <vendor>tool vendor</vendor>
+                <vendor>Service service group</vendor>
+                <name>sbom-generator-service</name>
+                <version>1</version>
+            </tool>
+            <tool>
+                <vendor>tool group</vendor>
                 <name>other tool</name>
             </tool>
             <tool>
-                <vendor>tool vendor</vendor>
+                <vendor>tool group</vendor>
                 <name>tool name</name>
                 <version>0.8.15</version>
                 <hashes>
-                    <hash alg="MD5">f32a26e2a3a8aa338cd77b6e1263c535</hash>
-                    <hash alg="SHA-1">829c3804401b0727f70f73d4415e162400cbe57b</hash>
+                    <hash alg="MD5">974e5cc07da6e4536bffd935fd4ddc61</hash>
+                    <hash alg="SHA-1">2aae6c35c94fcfb415dbe95f408b9ce91ee846ed</hash>
                 </hashes>
             </tool>
         </tools>
@@ -270,7 +275,7 @@
             </provider>
             <group>acme</group>
             <name>dummy-service</name>
-            <version>1.2+service-version</version>
+            <version>1.0+service-version</version>
             <description>this is a test service</description>
             <licenses>
                 <license>

--- a/tests/_data/serializeResults/xml_complex_spec1.4.xml.bin
+++ b/tests/_data/serializeResults/xml_complex_spec1.4.xml.bin
@@ -4,7 +4,18 @@
         <timestamp>2032-05-23T13:37:42.000Z</timestamp>
         <tools>
             <tool>
-                <vendor>tool vendor</vendor>
+                <vendor>Service service group</vendor>
+                <name>sbom-generator-service</name>
+                <version>1</version>
+                <externalReferences>
+                    <reference type="website">
+                        <url>https://example.com/sbom-generator-service/</url>
+                        <comment>the service that made this</comment>
+                    </reference>
+                </externalReferences>
+            </tool>
+            <tool>
+                <vendor>tool group</vendor>
                 <name>other tool</name>
                 <externalReferences>
                     <reference type="website">
@@ -14,12 +25,12 @@
                 </externalReferences>
             </tool>
             <tool>
-                <vendor>tool vendor</vendor>
+                <vendor>tool group</vendor>
                 <name>tool name</name>
                 <version>0.8.15</version>
                 <hashes>
-                    <hash alg="MD5">f32a26e2a3a8aa338cd77b6e1263c535</hash>
-                    <hash alg="SHA-1">829c3804401b0727f70f73d4415e162400cbe57b</hash>
+                    <hash alg="MD5">974e5cc07da6e4536bffd935fd4ddc61</hash>
+                    <hash alg="SHA-1">2aae6c35c94fcfb415dbe95f408b9ce91ee846ed</hash>
                 </hashes>
             </tool>
         </tools>
@@ -270,7 +281,7 @@
             </provider>
             <group>acme</group>
             <name>dummy-service</name>
-            <version>1.2+service-version</version>
+            <version>1.0+service-version</version>
             <description>this is a test service</description>
             <licenses>
                 <license>
@@ -469,6 +480,10 @@
                 </individuals>
             </credits>
             <tools>
+                <tool>
+                    <vendor>g the group</vendor>
+                    <name>other tool name</name>
+                </tool>
                 <tool>
                     <vendor>v the vendor</vendor>
                     <name>tool name</name>

--- a/tests/_data/serializeResults/xml_complex_spec1.5.xml.bin
+++ b/tests/_data/serializeResults/xml_complex_spec1.5.xml.bin
@@ -12,25 +12,40 @@
             </lifecycle>
         </lifecycles>
         <tools>
-            <tool>
-                <vendor>tool vendor</vendor>
-                <name>other tool</name>
-                <externalReferences>
-                    <reference type="website">
-                        <url>https://cyclonedx.org/tool-center/</url>
-                        <comment>the tools that made this</comment>
-                    </reference>
-                </externalReferences>
-            </tool>
-            <tool>
-                <vendor>tool vendor</vendor>
-                <name>tool name</name>
-                <version>0.8.15</version>
-                <hashes>
-                    <hash alg="MD5">f32a26e2a3a8aa338cd77b6e1263c535</hash>
-                    <hash alg="SHA-1">829c3804401b0727f70f73d4415e162400cbe57b</hash>
-                </hashes>
-            </tool>
+            <components>
+                <component type="library">
+                    <group>tool group</group>
+                    <name>other tool</name>
+                    <externalReferences>
+                        <reference type="website">
+                            <url>https://cyclonedx.org/tool-center/</url>
+                            <comment>the tools that made this</comment>
+                        </reference>
+                    </externalReferences>
+                </component>
+                <component type="application">
+                    <group>tool group</group>
+                    <name>tool name</name>
+                    <version>0.8.15</version>
+                    <hashes>
+                        <hash alg="MD5">974e5cc07da6e4536bffd935fd4ddc61</hash>
+                        <hash alg="SHA-1">2aae6c35c94fcfb415dbe95f408b9ce91ee846ed</hash>
+                    </hashes>
+                </component>
+            </components>
+            <services>
+                <service>
+                    <group>Service service group</group>
+                    <name>sbom-generator-service</name>
+                    <version>1</version>
+                    <externalReferences>
+                        <reference type="website">
+                            <url>https://example.com/sbom-generator-service/</url>
+                            <comment>the service that made this</comment>
+                        </reference>
+                    </externalReferences>
+                </service>
+            </services>
         </tools>
         <authors>
             <author>
@@ -279,7 +294,7 @@
             </provider>
             <group>acme</group>
             <name>dummy-service</name>
-            <version>1.2+service-version</version>
+            <version>1.0+service-version</version>
             <description>this is a test service</description>
             <licenses>
                 <license>
@@ -478,6 +493,10 @@
                 </individuals>
             </credits>
             <tools>
+                <tool>
+                    <vendor>g the group</vendor>
+                    <name>other tool name</name>
+                </tool>
                 <tool>
                     <vendor>v the vendor</vendor>
                     <name>tool name</name>

--- a/tests/_data/serializeResults/xml_complex_spec1.6.xml.bin
+++ b/tests/_data/serializeResults/xml_complex_spec1.6.xml.bin
@@ -12,25 +12,40 @@
             </lifecycle>
         </lifecycles>
         <tools>
-            <tool>
-                <vendor>tool vendor</vendor>
-                <name>other tool</name>
-                <externalReferences>
-                    <reference type="website">
-                        <url>https://cyclonedx.org/tool-center/</url>
-                        <comment>the tools that made this</comment>
-                    </reference>
-                </externalReferences>
-            </tool>
-            <tool>
-                <vendor>tool vendor</vendor>
-                <name>tool name</name>
-                <version>0.8.15</version>
-                <hashes>
-                    <hash alg="MD5">f32a26e2a3a8aa338cd77b6e1263c535</hash>
-                    <hash alg="SHA-1">829c3804401b0727f70f73d4415e162400cbe57b</hash>
-                </hashes>
-            </tool>
+            <components>
+                <component type="library">
+                    <group>tool group</group>
+                    <name>other tool</name>
+                    <externalReferences>
+                        <reference type="website">
+                            <url>https://cyclonedx.org/tool-center/</url>
+                            <comment>the tools that made this</comment>
+                        </reference>
+                    </externalReferences>
+                </component>
+                <component type="application">
+                    <group>tool group</group>
+                    <name>tool name</name>
+                    <version>0.8.15</version>
+                    <hashes>
+                        <hash alg="MD5">974e5cc07da6e4536bffd935fd4ddc61</hash>
+                        <hash alg="SHA-1">2aae6c35c94fcfb415dbe95f408b9ce91ee846ed</hash>
+                    </hashes>
+                </component>
+            </components>
+            <services>
+                <service>
+                    <group>Service service group</group>
+                    <name>sbom-generator-service</name>
+                    <version>1</version>
+                    <externalReferences>
+                        <reference type="website">
+                            <url>https://example.com/sbom-generator-service/</url>
+                            <comment>the service that made this</comment>
+                        </reference>
+                    </externalReferences>
+                </service>
+            </services>
         </tools>
         <authors>
             <author>
@@ -279,7 +294,7 @@
             </provider>
             <group>acme</group>
             <name>dummy-service</name>
-            <version>1.2+service-version</version>
+            <version>1.0+service-version</version>
             <description>this is a test service</description>
             <licenses>
                 <license>
@@ -478,6 +493,10 @@
                 </individuals>
             </credits>
             <tools>
+                <tool>
+                    <vendor>g the group</vendor>
+                    <name>other tool name</name>
+                </tool>
                 <tool>
                     <vendor>v the vendor</vendor>
                     <name>tool name</name>

--- a/tests/unit/Models.Vulnerability.Vulnerability.spec.js
+++ b/tests/unit/Models.Vulnerability.Vulnerability.spec.js
@@ -22,7 +22,7 @@ const { suite, test } = require('mocha')
 
 const {
   Models: {
-    PropertyRepository, ToolRepository,
+    PropertyRepository, Tools,
     Vulnerability: {
       AdvisoryRepository, AffectRepository, Analysis, Credits, RatingRepository, ReferenceRepository, Source,
       Vulnerability
@@ -53,7 +53,7 @@ suite('Models.Vulnerability.Vulnerability', () => {
     assert.strictEqual(vulnerability.published, undefined)
     assert.strictEqual(vulnerability.updated, undefined)
     assert.strictEqual(vulnerability.credits, undefined)
-    assert.ok(vulnerability.tools instanceof ToolRepository)
+    assert.ok(vulnerability.tools instanceof Tools)
     assert.strictEqual(vulnerability.tools.size, 0)
     assert.strictEqual(vulnerability.analysis, undefined)
     assert.ok(vulnerability.affects instanceof AffectRepository)
@@ -72,7 +72,7 @@ suite('Models.Vulnerability.Vulnerability', () => {
     const dummyPublished = new Date()
     const dummyUpdated = new Date()
     const dummyCredits = new Credits()
-    const dummyTools = new ToolRepository()
+    const dummyTools = new Tools()
     const dummyAnalysis = new Analysis()
     const dummyAffects = new AffectRepository()
     const dummyProperties = new PropertyRepository()


### PR DESCRIPTION
* BREAKING changes
  * Property `Models.Bom.tools` is an instance of `Models.Tools` now ([#1152] via [#1163])  
    Before, it was an instance of `Models.ToolRepository`.
* Added
  * Static function `Models.Tool.fromComponent()` (via [#1163])
  * Static function `Models.Tool.fromService()` (via [#1163])
  * New class `Models.Tools` ([#1152] via [#1163])
  * New serialization/normalization for `Models.Tools` ([#1152] via [#1163])
* Changed
  * Serializers and `Bom`-Normalizers will take changed `Models.Bom.tools` into account ([#1152] via [#1163])


----

fixes #1152

as described here in https://github.com/CycloneDX/cyclonedx-javascript-library/issues/1152#issuecomment-2417163184 
