### PR TITLE
feat: makeComponent - add build-system external reference

### DIFF
--- a/src/builders/fromNodePackageJson.node.ts
+++ b/src/builders/fromNodePackageJson.node.ts
@@ -90,7 +90,7 @@ export class ComponentBuilder {
     return this.#licenseFactory
   }
 
-  makeComponent (data: PackageJson, type: ComponentType = ComponentType.Library): Component | undefined {
+  makeComponent (data: PackageJson, type: ComponentType = ComponentType.Library, buildSystem: string | null = null): Component | undefined {
     if (typeof data.name !== 'string') {
       return undefined
     }
@@ -117,7 +117,7 @@ export class ComponentBuilder {
       ? data.version
       : undefined
 
-    const externalReferences = this.#extRefFactory.makeExternalReferences(data)
+    const externalReferences = this.#extRefFactory.makeExternalReferences(data, buildSystem)
 
     const licenses = new LicenseRepository()
     if (typeof data.license === 'string') {
@@ -145,5 +145,4 @@ export class ComponentBuilder {
       licenses,
       version
     })
-  }
-}
+  }}

--- a/src/factories/fromNodePackageJson.node.ts
+++ b/src/factories/fromNodePackageJson.node.ts
@@ -41,18 +41,19 @@ import { PackageUrlFactory as PlainPackageUrlFactory } from './packageUrl'
  * Node-specific ExternalReferenceFactory.
  */
 export class ExternalReferenceFactory {
-  makeExternalReferences (data: PackageJson): ExternalReference[] {
+  makeExternalReferences (data: PackageJson,  buildSystem: string | null = null): ExternalReference[] {
     const refs: Array<ExternalReference | undefined> = []
 
     try { refs.push(this.makeVcs(data)) } catch { /* pass */ }
     try { refs.push(this.makeHomepage(data)) } catch { /* pass */ }
     try { refs.push(this.makeIssueTracker(data)) } catch { /* pass */ }
+    try { refs.push(this.makeBuildSystem(buildSystem)) } catch { /* pass */ }
 
     return refs.filter(isNotUndefined)
   }
 
   makeVcs (data: PackageJson): ExternalReference | undefined {
-    /* see https://docs.npmjs.com/cli/v9/configuring-npm/package-json#repositoryc */
+    /* see https://docs.npmjs.com/cli/v9/configuring-npm/package-json#repository */
     const repository = data.repository
     let url = undefined
     let comment: string | undefined = undefined
@@ -99,6 +100,12 @@ export class ExternalReferenceFactory {
     return typeof url === 'string' && url.length > 0
       ? new ExternalReference(url, ExternalReferenceType.IssueTracker, { comment })
       : undefined
+  }
+
+  private makeBuildSystem(buildSystem: string | null): ExternalReference | undefined {
+    return buildSystem === null
+      ? undefined
+      : new ExternalReference(buildSystem, ExternalReferenceType.BuildSystem)
   }
 }
 

--- a/tests/integration/Factories.FromNodePackageJson.ExternalReferenceFactory.test.js
+++ b/tests/integration/Factories.FromNodePackageJson.ExternalReferenceFactory.test.js
@@ -266,4 +266,22 @@ suite('integration: Factories.FromNodePackageJson.ExternalReferenceFactory', () 
       assert.deepEqual(actual, expected)
     })
   })
+  suite('buildSystem provided', () => {
+    test('is non-empty string', () => {
+      const expected = [new ExternalReference(
+        'https://example.com/build',
+        ExternalReferenceType.BuildSystem
+      )]
+      const buildSystem = 'https://example.com/build'
+      const data = {}
+      const actual = sut.makeExternalReferences(data, buildSystem)
+      assert.deepEqual(actual, expected)
+    })
+
+    test('is null', () => {
+      const data = {}
+      const actual = sut.makeExternalReferences(data, null)
+      assert.strictEqual(actual.length, 0)
+    })
+  })
 })


### PR DESCRIPTION
Adds the capability to specify the `build-system` when generating a component. This is needed to support https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues/1344

@jkowalleck This is one way to add the `build-system`. I'm open to suggestions if you think this should be implemented differently.