### PR TITLE
build: tsconfig `skipLibCheck: true`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -102,7 +102,8 @@
 
     /* Completeness */
     "skipDefaultLibCheck": false,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": false                                 /* Skip type checking all .d.ts files. */
+    // needed for https://github.com/oozcitak/util/issues/13
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
caused by https://github.com/oozcitak/util/issues/13

some new transitive dependency was introduced, and this causes friction ... 
so we need to adjust our typing a bit ... 