### PR TITLE
feat: add npm engine constraint properties

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,9 +7,10 @@ All notable changes to this project will be documented in this file.
 <!-- add unreleased items here -->
 
 * Added
-  * Populate npm engine constraint properties from `package.json` ([#1506])
+  * `Contrib.FromNodePackageJson.Builders.ComponentBuilder` may populate properties with engine constraint ([#1506] via [#1507])
 
 [#1506]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/1506
+[#1507]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/1507
 
 ## 10.1.1 -- 2026-08-10
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 <!-- add unreleased items here -->
 
+* Added
+  * Populate npm engine constraint properties from `package.json` ([#1506])
+
+[#1506]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/1506
+
 ## 10.1.1 -- 2026-08-10
 
 Maintenance release.

--- a/src/contrib/fromNodePackageJson/builders.ts
+++ b/src/contrib/fromNodePackageJson/builders.ts
@@ -37,21 +37,6 @@ import { splitNameGroup } from './_helpers/packageJson'
 import type { ExternalReferenceFactory } from './factories'
 import type { NodePackageJson } from './types'
 
-function makeEngineProperties (engines: unknown): PropertyRepository {
-  const properties = new PropertyRepository()
-  if (engines === null || typeof engines !== 'object' || Array.isArray(engines)) {
-    return properties
-  }
-
-  for (const [engine, constraint] of Object.entries(engines)) {
-    if (typeof constraint === 'string') {
-      properties.add(new Property(`cdx:npm:package:constraint:engine:${engine}`, constraint))
-    }
-  }
-
-  return properties
-}
-
 /**
  * Node-specific ToolBuilder.
  */
@@ -136,8 +121,6 @@ export class ComponentBuilder {
 
     const externalReferences = this.#extRefFactory.makeExternalReferences(data)
 
-    const properties = makeEngineProperties(data.engines)
-
     const licenses = new LicenseRepository()
     if (typeof data.license === 'string') {
       /* see https://docs.npmjs.com/cli/v9/configuring-npm/package-json#license */
@@ -162,8 +145,23 @@ export class ComponentBuilder {
       externalReferences: new ExternalReferenceRepository(externalReferences),
       group,
       licenses,
-      properties,
+      properties: this.#makeEngineProperties(data.engines),
       version
     })
+  }
+
+  #makeEngineProperties (engines: unknown): PropertyRepository {
+    const properties = new PropertyRepository()
+    if (engines === null || typeof engines !== 'object' || Array.isArray(engines)) {
+      return properties
+    }
+
+    for (const [engine, constraint] of Object.entries(engines)) {
+      if (typeof constraint === 'string') {
+        properties.add(new Property(`cdx:npm:package:constraint:engine:${engine}`, constraint))
+      }
+    }
+
+    return properties
   }
 }

--- a/src/contrib/fromNodePackageJson/builders.ts
+++ b/src/contrib/fromNodePackageJson/builders.ts
@@ -139,29 +139,32 @@ export class ComponentBuilder {
       }
     }
 
+    const properties = new PropertyRepository(
+      this.#makeEngineProperties(data.engines)
+    )
+
     return new Component(type, name, {
       author,
       description,
       externalReferences: new ExternalReferenceRepository(externalReferences),
       group,
       licenses,
-      properties: this.#makeEngineProperties(data.engines),
+      properties,
       version
     })
   }
 
-  #makeEngineProperties (engines: unknown): PropertyRepository {
-    const properties = new PropertyRepository()
+  * #makeEngineProperties (engines: unknown): Generator<Property> {
     if (engines === null || typeof engines !== 'object' || Array.isArray(engines)) {
-      return properties
+      return;
     }
 
     for (const [engine, constraint] of Object.entries(engines)) {
       if (typeof constraint === 'string') {
-        properties.add(new Property(`cdx:npm:package:constraint:engine:${engine}`, constraint))
+        yield new Property(
+          `cdx:npm:package:constraint:engine:${engine}`,
+          constraint)
       }
     }
-
-    return properties
   }
 }

--- a/src/contrib/fromNodePackageJson/builders.ts
+++ b/src/contrib/fromNodePackageJson/builders.ts
@@ -30,11 +30,27 @@ import { ComponentType } from '../../enums/componentType'
 import { Component } from '../../models/component'
 import { ExternalReferenceRepository } from '../../models/externalReference'
 import { LicenseRepository } from '../../models/license'
+import { Property, PropertyRepository } from '../../models/property'
 import { Tool } from '../../models/tool'
 import type { LicenseFactory } from '../license/factories'
 import { splitNameGroup } from './_helpers/packageJson'
 import type { ExternalReferenceFactory } from './factories'
 import type { NodePackageJson } from './types'
+
+function makeEngineProperties (engines: unknown): PropertyRepository {
+  const properties = new PropertyRepository()
+  if (engines === null || typeof engines !== 'object' || Array.isArray(engines)) {
+    return properties
+  }
+
+  for (const [engine, constraint] of Object.entries(engines)) {
+    if (typeof constraint === 'string') {
+      properties.add(new Property(`cdx:npm:package:constraint:engine:${engine}`, constraint))
+    }
+  }
+
+  return properties
+}
 
 /**
  * Node-specific ToolBuilder.
@@ -120,6 +136,8 @@ export class ComponentBuilder {
 
     const externalReferences = this.#extRefFactory.makeExternalReferences(data)
 
+    const properties = makeEngineProperties(data.engines)
+
     const licenses = new LicenseRepository()
     if (typeof data.license === 'string') {
       /* see https://docs.npmjs.com/cli/v9/configuring-npm/package-json#license */
@@ -144,6 +162,7 @@ export class ComponentBuilder {
       externalReferences: new ExternalReferenceRepository(externalReferences),
       group,
       licenses,
+      properties,
       version
     })
   }

--- a/src/contrib/fromNodePackageJson/types.ts
+++ b/src/contrib/fromNodePackageJson/types.ts
@@ -47,6 +47,7 @@ export interface NodePackageJson {
     url?: string
     directory?: string
   }
+  engines?: Record<string, string>
   // ... to be continued
   dist?: any // see https://github.com/CycloneDX/cyclonedx-node-npm/issues/1300
 }

--- a/tests/integration/Contrib.FromNodePackageJson.Builders.ComponentBuilder.node.test.js
+++ b/tests/integration/Contrib.FromNodePackageJson.Builders.ComponentBuilder.node.test.js
@@ -108,6 +108,30 @@ suite('integration: Contrib.FromNodePackageJson.Builders.ComponentBuilder', () =
       new Models.Component(Enums.ComponentType.Library, 'foo')
     ],
     [
+      'ignore array engines',
+      {
+        name: 'foo',
+        engines: ['node', '>=20.18.0']
+      },
+      new Models.Component(Enums.ComponentType.Library, 'foo')
+    ],
+    [
+      'ignore null engines',
+      {
+        name: 'foo',
+        engines: null
+      },
+      new Models.Component(Enums.ComponentType.Library, 'foo')
+    ],
+    [
+      'ignore string engines',
+      {
+        name: 'foo',
+        engines: '>=20.18.0'
+      },
+      new Models.Component(Enums.ComponentType.Library, 'foo')
+    ],
+    [
       // Even though https://npmjs.org does not allow it,
       // there is nothing wrong with a package name that contains more than one slash(/).
       // It is completely compliant to NodeJS rules and will be properly resolved.

--- a/tests/integration/Contrib.FromNodePackageJson.Builders.ComponentBuilder.node.test.js
+++ b/tests/integration/Contrib.FromNodePackageJson.Builders.ComponentBuilder.node.test.js
@@ -61,6 +61,10 @@ suite('integration: Contrib.FromNodePackageJson.Builders.ComponentBuilder', () =
         repository: {
           type: 'git',
           url: 'https://github.com/foo/bar.git'
+        },
+        engines: {
+          node: '>=20.18.0',
+          npm: '^10.8.2'
         }
         // to be continued
       },
@@ -84,9 +88,24 @@ suite('integration: Contrib.FromNodePackageJson.Builders.ComponentBuilder', () =
             new Models.NamedLicense(`dummy license ${salt}`),
             new Models.NamedLicense(`some license ${salt}`),
           ]),
+          properties: new Models.PropertyRepository([
+            new Models.Property('cdx:npm:package:constraint:engine:node', '>=20.18.0'),
+            new Models.Property('cdx:npm:package:constraint:engine:npm', '^10.8.2'),
+          ]),
           version: `1.33.7-alpha.23.${salt}`
         }
       )
+    ],
+    [
+      'ignore malformed engine constraints',
+      {
+        name: 'foo',
+        engines: {
+          node: 22,
+          npm: null
+        }
+      },
+      new Models.Component(Enums.ComponentType.Library, 'foo')
     ],
     [
       // Even though https://npmjs.org does not allow it,


### PR DESCRIPTION
### Description

Populate `Component.properties` from the string-valued entries in a Node
package manifest's `engines` object. Each entry uses the existing CycloneDX
npm property taxonomy name
`cdx:npm:package:constraint:engine:<name>`.

Malformed non-string engine constraints are ignored, consistent with the
builder's defensive handling of other package manifest fields.

Fixes issue: #1506

### Verification

- `npm run test:node` (4,166 passing)
- `npm run test:lint`
- `npm run test:standard`
- `npm run test:dependencies`
- `npm run build:node`
- `npm run build:web`
- `npx tsc -b ./tsconfig.d.json`
- `npm pack --ignore-scripts`, followed by installation into a clean directory
  and runtime checks for valid constraints, malformed values, and a missing
  package name

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `OpenAI Codex`
  - LLMs and versions: `GPT-5`
  - Prompts: `Inspect issue #1506 and the repository contribution rules; implement only the required npm engine constraint properties; add positive and malformed-input regression coverage; run build, lint, full tests, package, and clean-install runtime verification.`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/CycloneDX/cyclonedx-javascript-library/blob/main/CONTRIBUTING.md) guidelines
