### PR TITLE
feat(contrib): populate component tags from npm keywords

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
-<!-- add unreleased items here -->
+* Added
+  * `Contrib.FromNodePackageJson.Builders.ComponentBuilder` populates component `tags` from the npm `keywords` property; `tags` are serialised in JSON and XML for CycloneDX 1.6 and later ([#1055])
+
+[#1055]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/1055
 
 ## 10.2.0 -- 2026-08-17
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,9 +5,12 @@ All notable changes to this project will be documented in this file.
 ## unreleased
 
 * Added
-  * `Contrib.FromNodePackageJson.Builders.ComponentBuilder` populates component `tags` from the npm `keywords` property; `tags` are serialised in JSON and XML for CycloneDX 1.6 and later ([#1055])
+  * Component model supports tags.
+  * Serializers and normalizers emit component tags.
+  * `Contrib.FromNodePackageJson.Builders.ComponentBuilder` may populate tags ([#1055] via [#1511]).
 
 [#1055]: https://github.com/CycloneDX/cyclonedx-javascript-library/issues/1055
+[#1511]: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/1511
 
 ## 10.2.0 -- 2026-08-17
 

--- a/src/contrib/fromNodePackageJson/builders.ts
+++ b/src/contrib/fromNodePackageJson/builders.ts
@@ -146,6 +146,11 @@ export class ComponentBuilder {
       group,
       licenses,
       properties,
+      tags: typeof data.keywords === 'string'
+        ? [data.keywords]
+        : (Array.isArray(data.keywords)
+          ? data.keywords.filter((k): k is string => typeof k === 'string')
+          : undefined),
       version
     })
   }

--- a/src/contrib/fromNodePackageJson/builders.ts
+++ b/src/contrib/fromNodePackageJson/builders.ts
@@ -138,6 +138,7 @@ export class ComponentBuilder {
     const properties = new PropertyRepository(
       this.#makeEngineProperties(data.engines)
     )
+    const tags = new Set(this.#makeTags(data.keywords))
 
     return new Component(type, name, {
       author,
@@ -146,11 +147,7 @@ export class ComponentBuilder {
       group,
       licenses,
       properties,
-      tags: typeof data.keywords === 'string'
-        ? [data.keywords]
-        : (Array.isArray(data.keywords)
-          ? data.keywords.filter((k): k is string => typeof k === 'string')
-          : undefined),
+      tags,
       version
     })
   }
@@ -177,6 +174,15 @@ export class ComponentBuilder {
       yield new Property(
         `cdx:npm:package:constraint:engine:${engine}`,
         constraint)
+    }
+  }
+
+  * #makeTags (keywords: NodePackageJson['keywords']): Generator<string> {
+    if (!Array.isArray(keywords)) return
+    for (const keyword of keywords) {
+      if (typeof keyword === 'string') {
+        yield keyword
+      }
     }
   }
 

--- a/src/contrib/fromNodePackageJson/types.ts
+++ b/src/contrib/fromNodePackageJson/types.ts
@@ -48,6 +48,7 @@ export interface NodePackageJson {
     directory?: string
   }
   engines?: Record<string, string>
+  keywords?: string[]
   // ... to be continued
   dist?: any // see https://github.com/CycloneDX/cyclonedx-node-npm/issues/1300
 }

--- a/src/models/component.ts
+++ b/src/models/component.ts
@@ -46,6 +46,7 @@ export interface OptionalComponentProperties {
   purl?: Component['purl']
   scope?: Component['scope']
   supplier?: Component['supplier']
+  tags?: Component['tags']
   swid?: Component['swid']
   version?: Component['version']
   components?: Component['components']
@@ -70,6 +71,7 @@ export class Component implements Comparable<Component> {
   purl?: string
   scope?: ComponentScope
   supplier?: OrganizationalEntity
+  tags?: string[]
   swid?: SWID
   version?: string
   components: ComponentRepository
@@ -92,6 +94,7 @@ export class Component implements Comparable<Component> {
     this.type = type
     this.name = name
     this.supplier = op.supplier
+    this.tags = op.tags
     this.author = op.author
     this.copyright = op.copyright
     this.externalReferences = op.externalReferences ?? new ExternalReferenceRepository()

--- a/src/models/component.ts
+++ b/src/models/component.ts
@@ -18,7 +18,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
 import type { Comparable } from '../_helpers/sortable'
-import { SortableComparables } from '../_helpers/sortable'
+import { SortableComparables, SortableStringables } from '../_helpers/sortable'
 import { treeIteratorSymbol } from '../_helpers/tree'
 import type { ComponentScope, ComponentType } from '../enums'
 import type { CPE } from '../types/cpe'
@@ -71,7 +71,7 @@ export class Component implements Comparable<Component> {
   purl?: string
   scope?: ComponentScope
   supplier?: OrganizationalEntity
-  tags?: string[]
+  tags: Set<string>
   swid?: SWID
   version?: string
   components: ComponentRepository
@@ -94,7 +94,7 @@ export class Component implements Comparable<Component> {
     this.type = type
     this.name = name
     this.supplier = op.supplier
-    this.tags = op.tags
+    this.tags = op.tags ?? new Set()
     this.author = op.author
     this.copyright = op.copyright
     this.externalReferences = op.externalReferences ?? new ExternalReferenceRepository()
@@ -148,7 +148,8 @@ export class Component implements Comparable<Component> {
     /* eslint-disable @typescript-eslint/strict-boolean-expressions -- run compares in weighted order */
     return (this.group ?? '').localeCompare(other.group ?? '') ||
       this.name.localeCompare(other.name) ||
-      (this.version ?? '').localeCompare(other.version ?? '')
+      (this.version ?? '').localeCompare(other.version ?? '') ||
+      new SortableStringables(this.tags).compare(new SortableStringables(other.tags))
     /* eslint-enable  @typescript-eslint/strict-boolean-expressions */
   }
 }

--- a/src/serialize/json/normalize.ts
+++ b/src/serialize/json/normalize.ts
@@ -426,6 +426,9 @@ export class ComponentNormalizer extends BaseJsonNormalizer<Models.Component> {
       properties: spec.supportsProperties(data) && data.properties.size > 0
         ? this._factory.makeForProperty().normalizeIterable(data.properties, options)
         : undefined,
+      tags: spec.supportsComponentTags && data.tags !== undefined && data.tags.length > 0
+        ? data.tags
+        : undefined,
       components: data.components.size > 0
         ? this.normalizeIterable(data.components, options)
         : undefined,

--- a/src/serialize/json/normalize.ts
+++ b/src/serialize/json/normalize.ts
@@ -426,8 +426,8 @@ export class ComponentNormalizer extends BaseJsonNormalizer<Models.Component> {
       properties: spec.supportsProperties(data) && data.properties.size > 0
         ? this._factory.makeForProperty().normalizeIterable(data.properties, options)
         : undefined,
-      tags: spec.supportsComponentTags && data.tags !== undefined && data.tags.length > 0
-        ? data.tags
+      tags: spec.supportsComponentTags && data.tags.size > 0
+        ? normalizeStringableIter(data.tags, options)
         : undefined,
       components: data.components.size > 0
         ? this.normalizeIterable(data.components, options)

--- a/src/serialize/json/types.ts
+++ b/src/serialize/json/types.ts
@@ -166,6 +166,7 @@ export namespace Normalized {
     components?: Component[]
     evidence?: ComponentEvidence
     properties?: Property[]
+    tags?: string[]
   }
 
   export interface Service {

--- a/src/serialize/xml/normalize.ts
+++ b/src/serialize/xml/normalize.ts
@@ -531,6 +531,13 @@ export class ComponentNormalizer extends BaseXmlNormalizer<Models.Component> {
           children: this._factory.makeForProperty().normalizeIterable(data.properties, options, 'property')
         }
       : undefined
+    const tags: SimpleXml.Element | undefined = spec.supportsComponentTags && data.tags !== undefined && data.tags.length > 0
+      ? {
+          type: 'element',
+          name: 'tags',
+          children: data.tags.map(value => makeTextElement(value, 'tag', normalizedString))
+        }
+      : undefined
     const components: SimpleXml.Element | undefined = data.components.size > 0
       ? {
           type: 'element',
@@ -565,6 +572,7 @@ export class ComponentNormalizer extends BaseXmlNormalizer<Models.Component> {
         swid,
         extRefs,
         properties,
+        tags,
         components,
         evidence
       ].filter(isNotUndefined)

--- a/src/serialize/xml/normalize.ts
+++ b/src/serialize/xml/normalize.ts
@@ -531,11 +531,11 @@ export class ComponentNormalizer extends BaseXmlNormalizer<Models.Component> {
           children: this._factory.makeForProperty().normalizeIterable(data.properties, options, 'property')
         }
       : undefined
-    const tags: SimpleXml.Element | undefined = spec.supportsComponentTags && data.tags !== undefined && data.tags.length > 0
+    const tags: SimpleXml.Element | undefined = spec.supportsComponentTags && data.tags.size > 0
       ? {
           type: 'element',
           name: 'tags',
-          children: data.tags.map(value => makeTextElement(value, 'tag', normalizedString))
+          children: makeTextElementIter(data.tags, options, 'tag', normalizedString)
         }
       : undefined
     const components: SimpleXml.Element | undefined = data.components.size > 0

--- a/src/spec/_protocol.ts
+++ b/src/spec/_protocol.ts
@@ -43,6 +43,7 @@ export interface _SpecProtocol {
   supportsVulnerabilities: boolean
   supportsVulnerabilityRatingMethod: (rm: Vulnerability.RatingMethod | any) => boolean
   supportsComponentEvidence: boolean
+  supportsComponentTags: boolean
   supportsMetadataLifecycles: boolean
   supportsMetadataLicenses: boolean
   supportsMetadataProperties: boolean
@@ -73,6 +74,7 @@ export class _Spec implements _SpecProtocol {
   readonly #supportsProperties: boolean
   readonly #supportsVulnerabilities: boolean
   readonly #supportsComponentEvidence: boolean
+  readonly #supportsComponentTags: boolean
   readonly #supportsMetadataLifecycles: boolean
   readonly #supportsMetadataLicenses: boolean
   readonly #supportsMetadataProperties: boolean
@@ -97,6 +99,7 @@ export class _Spec implements _SpecProtocol {
     supportsVulnerabilities: boolean,
     vulnerabilityRatingMethods: Iterable<Vulnerability.RatingMethod>,
     supportsComponentEvidence: boolean,
+    supportsComponentTags: boolean,
     supportsMetadataLifecycles: boolean,
     supportsMetadataLicenses: boolean,
     supportsMetadataProperties: boolean,
@@ -119,6 +122,7 @@ export class _Spec implements _SpecProtocol {
     this.#supportsVulnerabilities = supportsVulnerabilities
     this.#vulnerabilityRatingMethods = new Set(vulnerabilityRatingMethods)
     this.#supportsComponentEvidence = supportsComponentEvidence
+    this.#supportsComponentTags = supportsComponentTags
     this.#supportsMetadataLifecycles = supportsMetadataLifecycles
     this.#supportsMetadataLicenses = supportsMetadataLicenses
     this.#supportsMetadataProperties = supportsMetadataProperties
@@ -190,6 +194,10 @@ export class _Spec implements _SpecProtocol {
 
   get supportsComponentEvidence (): boolean {
     return this.#supportsComponentEvidence
+  }
+
+  get supportsComponentTags (): boolean {
+    return this.#supportsComponentTags
   }
 
   get supportsMetadataLifecycles (): boolean {

--- a/src/spec/consts.ts
+++ b/src/spec/consts.ts
@@ -88,6 +88,7 @@ export const Spec1dot2: Readonly<_SpecProtocol> = Object.freeze(new _Spec(
   false,
   false,
   false,
+  false,
   true,
   false,
   false
@@ -149,6 +150,7 @@ export const Spec1dot3: Readonly<_SpecProtocol> = Object.freeze(new _Spec(
   false,
   [],
   true,
+  false,
   false,
   true,
   true,
@@ -222,6 +224,7 @@ export const Spec1dot4: Readonly<_SpecProtocol> = Object.freeze(new _Spec(
     VulnerabilityRatingMethod.Other
   ],
   true,
+  false,
   false,
   true,
   true,
@@ -324,6 +327,7 @@ export const Spec1dot5: Readonly<_SpecProtocol> = Object.freeze(new _Spec(
     VulnerabilityRatingMethod.Other
   ],
   true,
+  false,
   true,
   true,
   true,
@@ -430,6 +434,7 @@ export const Spec1dot6: Readonly<_SpecProtocol> = Object.freeze(new _Spec(
     VulnerabilityRatingMethod.SSVC,
     VulnerabilityRatingMethod.Other
   ],
+  true,
   true,
   true,
   true,
@@ -545,6 +550,7 @@ export const Spec1dot7: Readonly<_SpecProtocol> = Object.freeze(new _Spec(
     VulnerabilityRatingMethod.SSVC,
     VulnerabilityRatingMethod.Other
   ],
+  true,
   true,
   true,
   true,

--- a/tests/_data/models.js
+++ b/tests/_data/models.js
@@ -148,6 +148,7 @@ function createComplexStructure () {
       Enums.ExternalReferenceType.ReleaseNotes // available since spec 1.4
     ))
     component.group = 'acme'
+    component.tags = new Set(['tag-b', 'tag-a'])
     component.hashes.set(Enums.HashAlgorithm['SHA-1'], 'e6f36746ccba42c288acf906e636bb278eaeb7e8')
     component.hashes.set(Enums.HashAlgorithm.MD5, '6bd3ac6fb35bb07c3f74d7f72451af57')
     component.hashes.set(Enums.HashAlgorithm['SHA-256'], 'something-invalid-according-to-spec')

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.6.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.6.json
@@ -397,6 +397,10 @@
           "comment": "testing"
         }
       ],
+      "tags": [
+        "tag-a",
+        "tag-b"
+      ],
       "evidence": {
         "licenses": [
           {

--- a/tests/_data/normalizeResults/json_sortedLists_spec1.7.json
+++ b/tests/_data/normalizeResults/json_sortedLists_spec1.7.json
@@ -397,6 +397,10 @@
           "comment": "testing"
         }
       ],
+      "tags": [
+        "tag-a",
+        "tag-b"
+      ],
       "evidence": {
         "licenses": [
           {

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.6.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.6.json
@@ -1198,6 +1198,22 @@
             },
             {
               "type": "element",
+              "name": "tags",
+              "children": [
+                {
+                  "type": "element",
+                  "name": "tag",
+                  "children": "tag-a"
+                },
+                {
+                  "type": "element",
+                  "name": "tag",
+                  "children": "tag-b"
+                }
+              ]
+            },
+            {
+              "type": "element",
               "name": "evidence",
               "children": [
                 {

--- a/tests/_data/normalizeResults/xml_sortedLists_spec1.7.json
+++ b/tests/_data/normalizeResults/xml_sortedLists_spec1.7.json
@@ -1198,6 +1198,22 @@
             },
             {
               "type": "element",
+              "name": "tags",
+              "children": [
+                {
+                  "type": "element",
+                  "name": "tag",
+                  "children": "tag-a"
+                },
+                {
+                  "type": "element",
+                  "name": "tag",
+                  "children": "tag-b"
+                }
+              ]
+            },
+            {
+              "type": "element",
               "name": "evidence",
               "children": [
                 {

--- a/tests/_data/serializeResults/json_complex_spec1.6.json.bin
+++ b/tests/_data/serializeResults/json_complex_spec1.6.json.bin
@@ -397,6 +397,10 @@
                     "comment": "testing"
                 }
             ],
+            "tags": [
+                "tag-a",
+                "tag-b"
+            ],
             "evidence": {
                 "licenses": [
                     {

--- a/tests/_data/serializeResults/json_complex_spec1.7.json.bin
+++ b/tests/_data/serializeResults/json_complex_spec1.7.json.bin
@@ -397,6 +397,10 @@
                     "comment": "testing"
                 }
             ],
+            "tags": [
+                "tag-a",
+                "tag-b"
+            ],
             "evidence": {
                 "licenses": [
                     {

--- a/tests/_data/serializeResults/xml_complex_spec1.6.xml.bin
+++ b/tests/_data/serializeResults/xml_complex_spec1.6.xml.bin
@@ -260,6 +260,10 @@
                     <comment>testing</comment>
                 </reference>
             </externalReferences>
+            <tags>
+                <tag>tag-a</tag>
+                <tag>tag-b</tag>
+            </tags>
             <evidence>
                 <licenses>
                     <license>

--- a/tests/_data/serializeResults/xml_complex_spec1.7.xml.bin
+++ b/tests/_data/serializeResults/xml_complex_spec1.7.xml.bin
@@ -260,6 +260,10 @@
                     <comment>testing</comment>
                 </reference>
             </externalReferences>
+            <tags>
+                <tag>tag-a</tag>
+                <tag>tag-b</tag>
+            </tags>
             <evidence>
                 <licenses>
                     <license>

--- a/tests/integration/Contrib.FromNodePackageJson.Builders.ComponentBuilder.node.test.js
+++ b/tests/integration/Contrib.FromNodePackageJson.Builders.ComponentBuilder.node.test.js
@@ -65,7 +65,8 @@ suite('integration: Contrib.FromNodePackageJson.Builders.ComponentBuilder', () =
         engines: {
           node: '>=20.18.0',
           npm: '^10.8.2'
-        }
+        },
+        keywords: ['alpha', 'beta']
         // to be continued
       },
       new Models.Component(
@@ -92,6 +93,7 @@ suite('integration: Contrib.FromNodePackageJson.Builders.ComponentBuilder', () =
             new Models.Property('cdx:npm:package:constraint:engine:node', '>=20.18.0'),
             new Models.Property('cdx:npm:package:constraint:engine:npm', '^10.8.2'),
           ]),
+          tags: ['alpha', 'beta'],
           version: `1.33.7-alpha.23.${salt}`
         }
       )

--- a/tests/integration/Contrib.FromNodePackageJson.Builders.ComponentBuilder.node.test.js
+++ b/tests/integration/Contrib.FromNodePackageJson.Builders.ComponentBuilder.node.test.js
@@ -93,10 +93,28 @@ suite('integration: Contrib.FromNodePackageJson.Builders.ComponentBuilder', () =
             new Models.Property('cdx:npm:package:constraint:engine:node', '>=20.18.0'),
             new Models.Property('cdx:npm:package:constraint:engine:npm', '^10.8.2'),
           ]),
-          tags: ['alpha', 'beta'],
+          tags: new Set(['alpha', 'beta']),
           version: `1.33.7-alpha.23.${salt}`
         }
       )
+    ],
+    [
+      'ignore string keywords',
+      {
+        name: 'foo',
+        keywords: 'alpha'
+      },
+      new Models.Component(Enums.ComponentType.Library, 'foo')
+    ],
+    [
+      'filter malformed keyword values',
+      {
+        name: 'foo',
+        keywords: ['alpha', 42, null, 'beta']
+      },
+      new Models.Component(Enums.ComponentType.Library, 'foo', {
+        tags: new Set(['alpha', 'beta'])
+      })
     ],
     [
       'ignore malformed engine constraints',

--- a/tests/unit/Models.Component.spec.js
+++ b/tests/unit/Models.Component.spec.js
@@ -52,6 +52,8 @@ suite('unit: Models.Component', () => {
     assert.strictEqual(component.purl, undefined)
     assert.strictEqual(component.scope, undefined)
     assert.strictEqual(component.supplier, undefined)
+    assert.ok(component.tags instanceof Set)
+    assert.strictEqual(component.tags.size, 0)
     assert.strictEqual(component.swid, undefined)
     assert.strictEqual(component.version, undefined)
     assert.strictEqual(component.components.size, 0)
@@ -80,6 +82,7 @@ suite('unit: Models.Component', () => {
       purl: dummyPurl,
       scope: 'optional',
       supplier: dummySupplier,
+      tags: new Set(['tag-a', 'tag-b']),
       swid: dummySWID,
       version: '1.33.7',
       components: new ComponentRepository([subComponent])
@@ -104,9 +107,30 @@ suite('unit: Models.Component', () => {
     assert.strictEqual(component.purl, dummyPurl)
     assert.strictEqual(component.scope, 'optional')
     assert.strictEqual(component.supplier, dummySupplier)
+    assert.deepStrictEqual(component.tags, new Set(['tag-a', 'tag-b']))
     assert.strictEqual(component.swid, dummySWID)
     assert.strictEqual(component.version, '1.33.7')
     assert.strictEqual(component.components.size, 1)
     assert.strictEqual(Array.from(component.components)[0], subComponent)
+  })
+
+  test('compare includes tags after the component identity fields', () => {
+    const left = new Component('library', 'foobar', {
+      bomRef: 'same',
+      tags: new Set(['tag-a'])
+    })
+    const right = new Component('library', 'foobar', {
+      bomRef: 'same',
+      tags: new Set(['tag-b'])
+    })
+
+    assert.notStrictEqual(left.compare(right), 0)
+    assert.strictEqual(
+      left.compare(new Component('library', 'foobar', {
+        bomRef: 'same',
+        tags: new Set(['tag-a'])
+      })),
+      0
+    )
   })
 })


### PR DESCRIPTION
**Closes #1055**

## Summary

Adds `tags` support to the Component model and populates it from array-form npm `package.json` `keywords`, serializing tags in both JSON and XML for CycloneDX 1.6 and later.

## Changes

- `Component.tags` is a `Set<string>` with an empty default and participates in component comparison.
- `Contrib.FromNodePackageJson.Builders.ComponentBuilder` collects normalized array-form keywords through a dedicated generator, ignores non-array input, and filters non-string entries.
- JSON and XML normalizers emit sorted tags for CycloneDX 1.6 and 1.7 only.
- `createComplexStructure` covers tags and the JSON/XML normalization and serialization snapshots are updated for 1.6/1.7.
- Builder and model tests cover empty/default tags, malformed keywords, and comparison behavior.
- `HISTORY.md` records the model, serializer/normalizer, and contrib-builder capabilities separately.

The unrelated entity-address work remains split into #1513.

## Verification

- Full Node test suite: 4170 passing, 4 pending, 0 failing
- `npm run test:lint`: passed
- Full repository ESLint: passed
- `npm run build:node`: passed
- `npm run build:web`: passed
- Type declaration build stage: passed (the existing Windows `cpy` post-script reports `No files matched`)

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: OpenAI Codex
  - LLMs and versions: GPT-5 family
  - Prompts: Asked Codex to implement component tags from normalized npm keywords, follow maintainer review on data shape, comparison, changelog and fixture snapshots, and verify the focused and full test/build paths.